### PR TITLE
feat: Add core mathematical types for Boolean formulas

### DIFF
--- a/lean/SATGame.lean
+++ b/lean/SATGame.lean
@@ -1,8 +1,26 @@
+import SATGame.Boolean.Literal
+import SATGame.CNF.Clause
+import SATGame.CNF.Formula
+import SATGame.CNF.Satisfiability
+import SATGame.Util.List
+
 /-!
 # SAT Game Library
 
 Formal verification of termination and correctness for the two-player SAT Game.
 
-This is the main module that will import all components of the SAT Game verification.
-Currently this serves as the project infrastructure setup.
+## Core Mathematical Types
+
+This module imports the fundamental mathematical types for the SAT Game:
+
+### Boolean Logic Foundation
+- `Boolean.Literal`: Literals with variables and boolean values
+- `CNF.Clause`: Disjunctions of literals
+- `CNF.Formula`: Conjunctions of clauses (CNF formulas)
+- `CNF.Satisfiability`: Satisfiability definitions and properties
+
+### Utilities
+- `Util.List`: Helper functions and lemmas for list operations
+
+These types form the mathematical foundation for all formula operations and game logic.
 -/

--- a/lean/SATGame/Boolean/Literal.lean
+++ b/lean/SATGame/Boolean/Literal.lean
@@ -1,0 +1,45 @@
+/-!
+# Boolean Literals
+
+Defines positive and negative variable literals for CNF formulas.
+
+A literal is either a positive variable `x` or its negation `¬x`.
+Provides evaluation functions, variable containment checks, and fundamental properties.
+-/
+
+/-- A literal is either a positive or negative variable -/
+inductive Literal (Var : Type) where
+  | pos : Var → Literal Var  -- positive literal (e.g., x)
+  | neg : Var → Literal Var  -- negative literal (e.g., ¬x)
+  deriving DecidableEq
+
+/-- Evaluate a literal under a boolean assignment to its variable -/
+def Literal.eval {Var : Type} (lit : Literal Var) (value : Bool) : Bool :=
+  match lit with
+  | Literal.pos _ => value     -- positive literal x is true when x := true
+  | Literal.neg _ => !value    -- negative literal ¬x is true when x := false
+
+/-- Extract the variable from a literal -/
+def Literal.getVariable {Var : Type} (lit : Literal Var) : Var :=
+  match lit with
+  | Literal.pos v => v
+  | Literal.neg v => v
+
+/-- Check if a literal contains a specific variable (either positive or negative) -/
+def Literal.containsVariable {Var : Type} [DecidableEq Var] (lit : Literal Var) (var : Var) : Bool :=
+  decide (lit.getVariable = var)
+
+/-- Check if a literal becomes true when a specific variable is assigned a value -/
+def Literal.becomesTrueUnder {Var : Type} [DecidableEq Var] (lit : Literal Var) (var : Var) (value : Bool) : Bool :=
+  lit.containsVariable var && lit.eval value
+
+/-- A literal always contains its own variable -/
+theorem Literal.contains_own_variable {Var : Type} [DecidableEq Var] (lit : Literal Var) :
+    lit.containsVariable lit.getVariable = true := by
+  unfold containsVariable getVariable
+  simp
+
+/-- Every literal contains at least one variable (namely, its own) -/
+theorem literal_contains_variable {Var : Type} [DecidableEq Var] (literal : Literal Var) :
+    ∃ var, literal.containsVariable var = true := by
+  exact ⟨literal.getVariable, literal.contains_own_variable⟩

--- a/lean/SATGame/CNF/Clause.lean
+++ b/lean/SATGame/CNF/Clause.lean
@@ -1,0 +1,39 @@
+import SATGame.Boolean.Literal
+
+/-!
+# CNF Clauses
+
+Defines clauses as disjunctions (OR) of literals.
+
+A clause is a list of literals representing their disjunction.
+Empty clauses are unsatisfiable; non-empty clauses contribute to the literal count.
+Provides containment checks and fundamental properties.
+-/
+
+/-- A clause is a disjunction (OR) of literals -/
+def Clause (Var : Type) := List (Literal Var)
+
+/-- Check if the clause is empty (contains no literals) -/
+def Clause.isEmpty {Var : Type} (clause : Clause Var) : Bool :=
+  List.isEmpty clause
+
+/-- Check if the clause contains any literal with the given variable -/
+def Clause.containsVariable {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) : Bool :=
+  clause.any (fun lit => lit.containsVariable var)
+
+/-- If any literal in a clause contains a variable, then the clause contains that variable -/
+theorem literal_var_implies_clause_var {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) :
+    (∃ lit, List.Mem lit clause ∧ lit.containsVariable var = true) → clause.containsVariable var = true := by
+  intro ⟨lit, h_lit_in, h_lit_contains⟩
+  unfold Clause.containsVariable
+  rw [List.any_eq_true]
+  exact ⟨lit, h_lit_in, h_lit_contains⟩
+
+/-- Check if a clause is satisfied by assigning a specific variable to a value -/
+def Clause.satisfiedBy {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) : Bool :=
+  clause.any (Literal.becomesTrueUnder · var value)
+
+@[simp] theorem Clause.satisfiedBy_def {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) :
+  Clause.satisfiedBy clause var value = clause.any (Literal.becomesTrueUnder · var value) := rfl

--- a/lean/SATGame/CNF/Formula.lean
+++ b/lean/SATGame/CNF/Formula.lean
@@ -1,0 +1,31 @@
+import SATGame.CNF.Clause
+
+/-!
+# CNF Formulas
+
+Defines formulas as conjunctions (AND) of clauses.
+
+A CNF formula is a list of clauses representing their conjunction.
+Provides predicates for checking variable containment, empty clauses, and fundamental properties.
+-/
+
+/-- A CNF formula is a conjunction (AND) of clauses -/
+def Formula (Var : Type) := List (Clause Var)
+
+/-- Check if any clause in the formula contains the given variable -/
+def Formula.containsVariable {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) : Bool :=
+  formula.any (fun clause => clause.containsVariable var)
+
+/-- If any clause in a formula contains a variable, then the formula contains that variable -/
+theorem clause_var_implies_formula_var {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) :
+    (∃ clause, List.Mem clause formula ∧ clause.containsVariable var = true) → formula.containsVariable var = true := by
+  intro ⟨clause, h_clause_in, h_clause_contains⟩
+  unfold Formula.containsVariable
+  rw [List.any_eq_true]
+  exact ⟨clause, h_clause_in, h_clause_contains⟩
+
+/-- Check if the formula contains any empty clause, making it unsatisfiable -/
+def Formula.hasEmptyClause {Var : Type} (formula : Formula Var) : Bool :=
+  formula.any (fun clause => clause.isEmpty)

--- a/lean/SATGame/CNF/Satisfiability.lean
+++ b/lean/SATGame/CNF/Satisfiability.lean
@@ -1,0 +1,127 @@
+import SATGame.CNF.Formula
+import SATGame.CNF.Clause
+import SATGame.Boolean.Literal
+
+/-!
+# Satisfiability for CNF Formulas
+
+Defines what it means for a CNF formula to be satisfiable.
+
+A formula is satisfiable if there exists an assignment of boolean values to variables
+such that every clause in the formula evaluates to true.
+-/
+
+/-- An assignment maps variables to boolean values -/
+def Assignment (Var : Type) := Var → Bool
+
+/-- Check if a literal is satisfied by an assignment -/
+def Literal.satisfiedByAssignment {Var : Type} [DecidableEq Var] (lit : Literal Var) (α : Assignment Var) : Bool :=
+  match lit with
+  | Literal.pos v => α v
+  | Literal.neg v => !(α v)
+
+/-- Check if a clause is satisfied by an assignment -/
+def Clause.satisfiedByAssignment {Var : Type} [DecidableEq Var] (clause : Clause Var) (α : Assignment Var) : Bool :=
+  clause.any (fun lit => lit.satisfiedByAssignment α)
+
+/-- Check if a formula is satisfied by an assignment -/
+def Formula.satisfiedByAssignment {Var : Type} [DecidableEq Var] (formula : Formula Var) (α : Assignment Var) : Bool :=
+  formula.all (fun clause => clause.satisfiedByAssignment α)
+
+/-- A formula is satisfiable if there exists some assignment that satisfies it -/
+def Formula.IsSatisfiable {Var : Type} [DecidableEq Var] (formula : Formula Var) : Prop :=
+  ∃ α : Assignment Var, formula.satisfiedByAssignment α = true
+
+/-!
+## Basic Properties
+-/
+
+/--
+A formula is a minimal unsatisfiable core if it's unsatisfiable and removing any clause makes it satisfiable.
+
+This captures the notion that every clause is essential for the unsatisfiability.
+-/
+def Formula.IsMinimalUnsatisfiableCore {Var : Type} [DecidableEq Var] (formula : Formula Var) : Prop :=
+  ¬(Formula.IsSatisfiable formula) ∧
+  ∀ (index : Nat), index < formula.length → Formula.IsSatisfiable (formula.eraseIdx index)
+
+/-- Empty formula is satisfiable -/
+theorem empty_formula_satisfiable {Var : Type} [DecidableEq Var] :
+    Formula.IsSatisfiable ([] : Formula Var) :=
+  ⟨fun _ => true, rfl⟩
+
+/-- Formulas containing empty clauses are unsatisfiable -/
+theorem formula_with_empty_clause_unsatisfiable {Var : Type} [DecidableEq Var] (formula : Formula Var)
+    (h_has_empty : formula.hasEmptyClause = true) :
+    ¬formula.IsSatisfiable := by
+  -- Prove by contradiction: assume formula is satisfiable
+  intro h_satisfiable
+  obtain ⟨assignment, h_assignment_satisfies⟩ := h_satisfiable
+
+  -- Extract the empty clause
+  unfold Formula.hasEmptyClause at h_has_empty
+  rw [List.any_eq_true] at h_has_empty
+  obtain ⟨empty_clause, h_empty_in_formula, h_empty_clause_isEmpty⟩ := h_has_empty
+
+  -- The assignment must satisfy all clauses, including the empty one
+  unfold Formula.satisfiedByAssignment at h_assignment_satisfies
+  rw [List.all_eq_true] at h_assignment_satisfies
+  have h_empty_satisfied := h_assignment_satisfies empty_clause h_empty_in_formula
+
+  -- But empty clauses cannot be satisfied
+  unfold Clause.satisfiedByAssignment at h_empty_satisfied
+  unfold Clause.isEmpty at h_empty_clause_isEmpty
+  -- List.isEmpty l = true means l = []
+  rw [List.isEmpty_iff] at h_empty_clause_isEmpty
+  rw [h_empty_clause_isEmpty] at h_empty_satisfied
+  -- h_empty_satisfied : [].any (fun lit => lit.satisfiedByAssignment assignment) = true
+  -- But [].any f = false for any f
+  simp at h_empty_satisfied
+
+/-- Extending assignment to fix a variable preserves literal satisfaction for unrelated literals -/
+theorem assignment_extension_preserves_unrelated_literals {Var : Type} [DecidableEq Var]
+    (lit : Literal Var) (α : Assignment Var) (var : Var) (value : Bool) :
+    ¬(lit.containsVariable var) →
+    lit.satisfiedByAssignment α = lit.satisfiedByAssignment (fun v => if v = var then value else α v) := by
+  intro h_unrelated
+  unfold Literal.satisfiedByAssignment
+  cases lit with
+  | pos v =>
+    unfold Literal.containsVariable Literal.getVariable at h_unrelated
+    simp at h_unrelated
+    simp [h_unrelated]
+  | neg v =>
+    unfold Literal.containsVariable Literal.getVariable at h_unrelated
+    simp at h_unrelated
+    simp [h_unrelated]
+
+/-- If a literal becomes true under variable assignment, it's satisfied by the extended assignment -/
+theorem becomesTrueUnder_implies_satisfiedBy_extension {Var : Type} [DecidableEq Var]
+    (lit : Literal Var) (var : Var) (value : Bool) (α : Assignment Var) :
+    lit.becomesTrueUnder var value = true →
+    lit.satisfiedByAssignment (fun v => if v = var then value else α v) = true := by
+  intro h_becomes_true
+  unfold Literal.satisfiedByAssignment
+  unfold Literal.becomesTrueUnder at h_becomes_true
+  -- h_becomes_true: lit.containsVariable var && lit.eval value = true
+  -- This means both lit.containsVariable var = true and lit.eval value = true
+  simp only [Bool.and_eq_true] at h_becomes_true
+  have h_contains := h_becomes_true.1
+  have h_eval := h_becomes_true.2
+  cases lit with
+  | pos v =>
+    simp only [Literal.eval] at h_eval ⊢
+    -- h_contains: (pos v).containsVariable var = true
+    -- This means v = var
+    unfold Literal.containsVariable Literal.getVariable at h_contains
+    simp at h_contains
+    rw [if_pos h_contains]
+    exact h_eval
+  | neg v =>
+    simp only [Literal.eval] at h_eval ⊢
+    -- h_contains: (neg v).containsVariable var = true
+    -- This means v = var
+    unfold Literal.containsVariable Literal.getVariable at h_contains
+    simp at h_contains
+    rw [if_pos h_contains]
+    exact h_eval

--- a/lean/SATGame/Util/List.lean
+++ b/lean/SATGame/Util/List.lean
@@ -1,0 +1,215 @@
+import Batteries.Data.List.Basic
+
+/-!
+# List Utilities
+
+Helper theorems for proving termination via list sum properties.
+
+This file contains general-purpose theorems about lists that could be useful
+in various contexts, not specific to SAT or Boolean logic.
+-/
+
+-- Helper: filterMap sum is at most original sum when elements don't increase
+theorem List.filterMap_sum_le {α β : Type} (l : List α) (g : α → Option β) (h : β → Nat) (f : α → Nat)
+    (h_nonincreasing : ∀ a ∈ l, ∀ b, g a = some b → h b ≤ f a) :
+    ((l.filterMap g).map h).sum ≤ (l.map f).sum := by
+  induction l with
+  | nil => simp
+  | cons head tail ih =>
+    simp only [List.filterMap_cons, List.map_cons, List.sum_cons]
+    cases h_g : g head with
+    | none =>
+      simp only [h_g]
+      have h_tail : ∀ a ∈ tail, ∀ b, g a = some b → h b ≤ f a := by
+        intros a ha b hb
+        exact h_nonincreasing a (List.mem_cons_of_mem head ha) b hb
+      show ((tail.filterMap g).map h).sum ≤ f head + (tail.map f).sum
+      exact Nat.le_trans (ih h_tail) (Nat.le_add_left (tail.map f).sum (f head))
+    | some head_result =>
+      simp only [h_g, List.map_cons, List.sum_cons]
+      have h_head_le : h head_result ≤ f head := by
+        have h_mem : head ∈ head :: tail := List.mem_cons_self
+        exact h_nonincreasing head h_mem head_result h_g
+      have h_tail : ∀ a ∈ tail, ∀ b, g a = some b → h b ≤ f a := by
+        intros a ha b hb
+        exact h_nonincreasing a (List.mem_cons_of_mem head ha) b hb
+      exact Nat.add_le_add h_head_le (ih h_tail)
+
+-- Specific utility for setVariable proof: witness element removed
+theorem List.sum_filterMap_lt_of_witness_removed {α β : Type}
+    (l : List α) (f : α → Nat) (g : α → Option β) (h : β → Nat)
+    (witness : α) (h_witness_mem : witness ∈ l)
+    (h_witness_removed : g witness = none)
+    (h_witness_pos : f witness > 0)
+    (h_others_nonincreasing : ∀ a ∈ l, ∀ b, g a = some b → h b ≤ f a) :
+    ((l.filterMap g).map h).sum < (l.map f).sum := by
+  -- Use induction on the list
+  induction l with
+  | nil => contradiction
+  | cons head tail ih =>
+    simp only [List.filterMap_cons, List.map_cons, List.sum_cons]
+    by_cases h_eq : head = witness
+    · -- Case: head is the witness
+      subst h_eq
+      rw [h_witness_removed]
+      simp only [List.map_nil, List.sum_nil, Nat.zero_add]
+      -- Now we need: ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+      have h_tail_le : ((tail.filterMap g).map h).sum ≤ (tail.map f).sum := by
+        apply filterMap_sum_le
+        intros a ha b hb
+        -- After subst, need to reason about membership in the original list
+        have h_mem_orig : a ∈ head :: tail := List.mem_cons_of_mem head ha
+        exact h_others_nonincreasing a h_mem_orig b hb
+      calc ((tail.filterMap g).map h).sum
+        ≤ (tail.map f).sum := h_tail_le
+        _ < f head + (tail.map f).sum := Nat.lt_add_of_pos_left h_witness_pos
+    · -- Case: head is not the witness
+      have h_witness_in_tail : witness ∈ tail := by
+        rw [List.mem_cons] at h_witness_mem
+        cases h_witness_mem with
+        | inl h => exact absurd h.symm h_eq
+        | inr h => exact h
+      -- Apply IH to tail
+      have h_tail_others : ∀ a ∈ tail, ∀ b, g a = some b → h b ≤ f a := by
+        intros a ha b hb
+        exact h_others_nonincreasing a (List.mem_cons_of_mem head ha) b hb
+      have ih_result := ih h_witness_in_tail h_tail_others
+      cases h_g : g head with
+      | none =>
+        -- Head gets filtered out
+        simp only [h_g]
+        show ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+        calc ((tail.filterMap g).map h).sum
+          < (tail.map f).sum := ih_result
+          _ ≤ f head + (tail.map f).sum := Nat.le_add_left (tail.map f).sum (f head)
+      | some head_result =>
+        -- Head passes through
+        simp only [h_g, List.map_cons, List.sum_cons]
+        have h_head_le : h head_result ≤ f head := by
+          exact h_others_nonincreasing head (List.mem_cons_self) head_result h_g
+        show h head_result + ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+        calc h head_result + ((tail.filterMap g).map h).sum
+          < h head_result + (tail.map f).sum := Nat.add_lt_add_left ih_result _
+          _ ≤ f head + (tail.map f).sum := Nat.add_le_add_right h_head_le _
+
+-- Specific utility for setVariable proof: witness element decreased
+theorem List.sum_filterMap_lt_of_witness_decreased {α β : Type}
+    (l : List α) (f : α → Nat) (g : α → Option β) (h : β → Nat)
+    (witness : α) (h_witness_mem : witness ∈ l)
+    (witness_result : β) (h_witness_maps : g witness = some witness_result)
+    (h_witness_decreased : h witness_result < f witness)
+    (h_others_nonincreasing : ∀ a ∈ l, ∀ b, g a = some b → h b ≤ f a) :
+    ((l.filterMap g).map h).sum < (l.map f).sum := by
+  -- Use induction on the list
+  induction l with
+  | nil => contradiction
+  | cons head tail ih =>
+    simp only [List.filterMap_cons, List.map_cons, List.sum_cons]
+    by_cases h_eq : head = witness
+    · -- Case: head is the witness
+      subst h_eq
+      rw [h_witness_maps]
+      simp only [List.map_cons, List.sum_cons]
+      -- Now we need: h witness_result + ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+      have h_tail_le : ((tail.filterMap g).map h).sum ≤ (tail.map f).sum := by
+        apply filterMap_sum_le
+        intros a ha b hb
+        exact h_others_nonincreasing a (List.mem_cons_of_mem head ha) b hb
+      calc h witness_result + ((tail.filterMap g).map h).sum
+        ≤ h witness_result + (tail.map f).sum := Nat.add_le_add_left h_tail_le _
+        _ < f head + (tail.map f).sum := Nat.add_lt_add_right h_witness_decreased (tail.map f).sum
+    · -- Case: head is not the witness
+      have h_witness_in_tail : witness ∈ tail := by
+        rw [List.mem_cons] at h_witness_mem
+        cases h_witness_mem with
+        | inl h => exact absurd h.symm h_eq
+        | inr h => exact h
+      -- Apply IH to tail
+      have h_tail_others : ∀ a ∈ tail, ∀ b, g a = some b → h b ≤ f a := by
+        intros a ha b hb
+        exact h_others_nonincreasing a (List.mem_cons_of_mem head ha) b hb
+      have ih_result := ih h_witness_in_tail h_tail_others
+      cases h_g : g head with
+      | none =>
+        -- Head gets filtered out
+        simp only [h_g]
+        show ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+        calc ((tail.filterMap g).map h).sum
+          < (tail.map f).sum := ih_result
+          _ ≤ f head + (tail.map f).sum := Nat.le_add_left (tail.map f).sum (f head)
+      | some head_result =>
+        -- Head passes through
+        simp only [h_g, List.map_cons, List.sum_cons]
+        have h_head_le : h head_result ≤ f head := by
+          exact h_others_nonincreasing head (List.mem_cons_self) head_result h_g
+        show h head_result + ((tail.filterMap g).map h).sum < f head + (tail.map f).sum
+        calc h head_result + ((tail.filterMap g).map h).sum
+          < h head_result + (tail.map f).sum := Nat.add_lt_add_left ih_result _
+          _ ≤ f head + (tail.map f).sum := Nat.add_le_add_right h_head_le _
+
+-- General lemma: erasing any element never increases the sum
+theorem List.sum_map_eraseIdx_le {α : Type} (l : List α) (f : α → Nat) (index : Nat) :
+    ((l.eraseIdx index).map f).sum ≤ (l.map f).sum := by
+  by_cases h_index : index < l.length
+  · -- Valid index: eraseIdx creates a sublist, and sum over sublist ≤ original sum
+    -- Use induction on the list structure
+    induction l generalizing index with
+    | nil =>
+      simp at h_index  -- contradiction: index < 0
+    | cons head tail ih =>
+      cases index with
+      | zero =>
+        -- Removing head: eraseIdx 0 (head :: tail) = tail
+        simp only [List.eraseIdx_cons_zero, List.map_cons, List.sum_cons]
+        exact Nat.le_add_left (tail.map f).sum (f head)
+      | succ n =>
+        -- Removing from tail: eraseIdx (n+1) (head :: tail) = head :: eraseIdx n tail
+        simp only [List.eraseIdx_cons_succ, List.map_cons, List.sum_cons]
+        -- Apply inductive hypothesis to tail
+        have h_tail_index : n < tail.length := by
+          -- From h_index : n.succ < (head :: tail).length = tail.length.succ
+          simp only [List.length_cons] at h_index
+          exact Nat.lt_of_succ_lt_succ h_index
+        have ih_applied := ih n h_tail_index
+        -- Goal: f head + ((tail.eraseIdx n).map f).sum ≤ f head + (tail.map f).sum
+        exact Nat.add_le_add_left ih_applied (f head)
+  · -- Invalid index: no change
+    simp [List.eraseIdx_of_length_le (Nat.le_of_not_gt h_index)]
+
+-- Removing an element with positive contribution decreases the sum
+theorem sum_eraseIdx_lt {α : Type} (l : List α) (f : α → Nat) (index : Nat)
+    (h_index : index < l.length)
+    (h_pos : f (l.get ⟨index, h_index⟩) > 0) :
+    ((l.eraseIdx index).map f).sum < (l.map f).sum := by
+  -- Use induction on the index with the structural theorems
+  induction index generalizing l with
+  | zero =>
+    -- Base case: index = 0, so we're removing the head
+    cases l with
+    | nil =>
+      simp at h_index  -- contradiction: 0 < 0
+    | cons head tail =>
+      simp [List.eraseIdx_cons_zero, List.map, List.sum]
+      -- Goal: tail.map f).sum < f head + (tail.map f).sum
+      -- This follows from h_pos: f head > 0
+      exact Nat.lt_add_of_pos_left h_pos
+  | succ n ih =>
+    -- Inductive case: index = n + 1
+    cases l with
+    | nil =>
+      simp at h_index  -- contradiction: n + 1 < 0
+    | cons head tail =>
+      simp [List.eraseIdx_cons_succ, List.map, List.sum]
+      -- Goal: f head + (tail.eraseIdx n).map f).sum < f head + (tail.map f).sum
+      -- Use the inductive hypothesis on the tail
+      have ih_applied := ih tail
+      have h_tail_index : n < tail.length := by
+        simp [List.length] at h_index ⊢
+        omega
+      have h_tail_pos : f (tail.get ⟨n, h_tail_index⟩) > 0 := by
+        simp [List.get] at h_pos ⊢
+        exact h_pos
+      have tail_sum_lt := ih_applied h_tail_index h_tail_pos
+      -- Show that this is exactly what we need
+      show (List.map f (tail.eraseIdx n)).sum < (List.map f tail).sum
+      exact tail_sum_lt

--- a/lean/lakefile.toml
+++ b/lean/lakefile.toml
@@ -3,5 +3,10 @@ version = "0.1.0"
 author = "Eric S. Rogstad"
 defaultTargets = ["SATGame"]
 
+[[require]]
+name = "batteries"
+scope = "leanprover-community"
+rev = "v4.20.0"
+
 [[lean_lib]]
 name = "SATGame"


### PR DESCRIPTION
Implement fundamental types for SAT Game verification:

- Boolean.Literal: Literals with variables and boolean values
- CNF.Clause: Disjunctions of literals with evaluation functions
- CNF.Formula: Conjunctions of clauses (CNF formulas)
- CNF.Satisfiability: Satisfiability definitions and properties

- Util.List: Helper functions and lemmas for list operations

These types provide the mathematical foundation for formula operations, satisfiability checking, and game logic. All types include comprehensive evaluation functions and basic properties.

🤖 Generated with [Claude Code](https://claude.ai/code)