### PR TITLE
Complete Termination Proof for Boolean Formula Operations

### DIFF
--- a/lean/SATGame.lean
+++ b/lean/SATGame.lean
@@ -10,10 +10,17 @@ import SATGame.Util.List
 /-!
 # SAT Game Library
 
-Core mathematical types for Boolean satisfiability and CNF formulas.
+Core mathematical types for Boolean satisfiability and formula operations.
 
-## Components
-- **Boolean Logic**: Literals, clauses, formulas, and satisfiability
-- **Formula Operations**: Variable assignment, clause removal, and operation sequences
-- **Utilities**: List helpers and lemmas
+## Core Modules
+
+### Mathematical Foundation
+- `Boolean/`, `CNF/`: Basic types for literals, clauses, formulas, and satisfiability
+- `FormulaOps/`: Formula operation framework
+  - `FormulaOps.FormulaExt`: Extended formula properties (terminal predicates, literal counts)
+  - `FormulaOps.FormulaOps`: Core operations (setVariable, removeClause)
+  - `FormulaOps.ValidSequences`: Valid sequences of operations
+- `Util/`: Helper functions and lemmas for list operations
+
+These components provide the mathematical foundation for formula operations.
 -/

--- a/lean/SATGame.lean
+++ b/lean/SATGame.lean
@@ -4,23 +4,35 @@ import SATGame.CNF.Formula
 import SATGame.CNF.Satisfiability
 import SATGame.FormulaOps.FormulaExt
 import SATGame.FormulaOps.FormulaOps
+import SATGame.FormulaOps.Termination.Helpers
+import SATGame.FormulaOps.Termination.Helpers.SetVariableHelpers
+import SATGame.FormulaOps.Termination.Main
+import SATGame.FormulaOps.Termination.Nonterminal
+import SATGame.FormulaOps.Termination.RemoveClause
+import SATGame.FormulaOps.Termination.SetVariable
 import SATGame.FormulaOps.ValidSequences
-import SATGame.Util.List
 
 /-!
 # SAT Game Library
 
-Core mathematical types for Boolean satisfiability and formula operations.
+Mathematical foundations for Boolean satisfiability with termination verification.
+
+## Current Results
+
+### Mathematical Foundations (FormulaOps)
+- **Termination**: Formula operation sequences always terminate (see `FormulaOps/Termination/Main`)
+- **Nonterminal Properties**: Fundamental properties of formulas where operations can continue (see `FormulaOps/Termination/Nonterminal.lean`)
 
 ## Core Modules
 
 ### Mathematical Foundation
 - `Boolean/`, `CNF/`: Basic types for literals, clauses, formulas, and satisfiability
-- `FormulaOps/`: Formula operation framework
+- `FormulaOps/`: Formula operation sequences and their mathematical properties
   - `FormulaOps.FormulaExt`: Extended formula properties (terminal predicates, literal counts)
   - `FormulaOps.FormulaOps`: Core operations (setVariable, removeClause)
   - `FormulaOps.ValidSequences`: Valid sequences of operations
-- `Util/`: Helper functions and lemmas for list operations
+  - `FormulaOps.Termination/`: Proofs that operation sequences terminate
 
-These components provide the mathematical foundation for formula operations.
+### Utilities
+- `Util/`: Helper functions and lemmas for list operations
 -/

--- a/lean/SATGame/FormulaOps/FormulaExt.lean
+++ b/lean/SATGame/FormulaOps/FormulaExt.lean
@@ -8,11 +8,14 @@ Includes predicates for formula states and termination metrics.
 -/
 
 
-/-- Process clause when setting variable: remove if satisfied, else filter literals -/
+/-- Process a single clause during variable assignment:
+    remove satisfied clauses, filter literals from unsatisfied clauses -/
 def processClauseForVariableAssignment {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) : Option (Clause Var) :=
   if clause.satisfiedBy var value then
-    none
+    none  -- Remove satisfied clauses
   else
+    -- Remove all literals containing the variable from the clause
+    -- Since the clause isn't satisfied, none of these literals can be true
     some (clause.filter fun lit => ¬(lit.containsVariable var))
 
 /-- Set a variable to a value and simplify the formula accordingly -/
@@ -23,11 +26,14 @@ def Formula.setVariable {Var : Type} [DecidableEq Var] (formula : Formula Var) (
 def Formula.removeClause {Var : Type} (formula : Formula Var) (index : Nat) : Formula Var :=
   formula.eraseIdx index
 
-/-- Terminal formula: satisfiability is trivially determined (empty or has empty clause) -/
+/--
+A formula is terminal when either all clauses are satisfied (empty formula)
+or an empty clause exists (unsatisfiable).
+-/
 def Formula.isTerminal {Var : Type} (formula : Formula Var) : Bool :=
   formula.isEmpty || formula.hasEmptyClause
 
-/-- Nonterminal formula: operations can continue (not terminal) -/
+/-- A formula is nonterminal when it has at least one clause, and none of its clauses are empty -/
 def Formula.isNonterminal {Var : Type} (formula : Formula Var) : Bool :=
   formula.isTerminal = false
 
@@ -35,7 +41,10 @@ def Formula.isNonterminal {Var : Type} (formula : Formula Var) : Bool :=
 def Formula.countLiterals {Var : Type} (formula : Formula Var) : Nat :=
   formula.map (fun clause => clause.length) |>.sum
 
-/-- Terminal formulas are either empty or contain an empty clause -/
+/--
+Terminal formulas are either empty (trivially satisfiable) or contain
+an empty clause (trivially unsatisfiable).
+-/
 theorem terminal_formula_classification {Var : Type} (formula : Formula Var)
     (h_terminal : formula.isTerminal = true) :
     formula = [] ∨ formula.hasEmptyClause := by

--- a/lean/SATGame/FormulaOps/FormulaExt.lean
+++ b/lean/SATGame/FormulaOps/FormulaExt.lean
@@ -9,7 +9,7 @@ Includes predicates for formula states and termination metrics.
 
 
 /-- Process clause when setting variable: remove if satisfied, else filter literals -/
-def processClause {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) : Option (Clause Var) :=
+def processClauseForVariableAssignment {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) : Option (Clause Var) :=
   if clause.satisfiedBy var value then
     none
   else
@@ -17,7 +17,7 @@ def processClause {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Va
 
 /-- Set a variable to a value and simplify the formula accordingly -/
 def Formula.setVariable {Var : Type} [DecidableEq Var] (formula : Formula Var) (var : Var) (value : Bool) : Formula Var :=
-  formula.filterMap (processClause · var value)
+  formula.filterMap (processClauseForVariableAssignment · var value)
 
 /-- Remove the clause at the given index from the formula -/
 def Formula.removeClause {Var : Type} (formula : Formula Var) (index : Nat) : Formula Var :=

--- a/lean/SATGame/FormulaOps/FormulaOps.lean
+++ b/lean/SATGame/FormulaOps/FormulaOps.lean
@@ -3,7 +3,14 @@ import SATGame.FormulaOps.FormulaExt
 /-!
 # Formula Operations
 
-Defines the FormulaOp type for formula transformations (SetVariable, RemoveClause).
+This module defines the FormulaOp type representing formula transformations.
+
+## Operations
+
+1. **SetVariable**: Assign a variable to true/false
+2. **RemoveClause**: Remove a clause by index
+
+Both operations are applied to formulas through `Formula.applyOp`.
 -/
 
 /-- Formula transformation operations -/

--- a/lean/SATGame/FormulaOps/Termination/Helpers.lean
+++ b/lean/SATGame/FormulaOps/Termination/Helpers.lean
@@ -1,0 +1,27 @@
+import SATGame.FormulaOps.FormulaExt
+
+/-!
+# Termination Helpers
+
+Basic utilities for termination proofs.
+
+This module contains:
+- Helper functions for literal and clause operations
+- Basic case analysis helpers
+- Simple utility theorems
+-/
+
+-- Helper: Simple case analysis for setVariable outcomes
+theorem setVariable_case_analysis {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var) (value : Bool) :
+    (clause.any (fun lit => match lit with
+      | Literal.pos v => v = var && value
+      | Literal.neg v => v = var && !value)) ∨
+    ¬(clause.any (fun lit => match lit with
+      | Literal.pos v => v = var && value
+      | Literal.neg v => v = var && !value)) := by
+  by_cases hSatisfied : clause.any (fun lit => match lit with
+    | Literal.pos v => v = var && value
+    | Literal.neg v => v = var && !value)
+  · left; exact hSatisfied
+  · right; exact hSatisfied
+

--- a/lean/SATGame/FormulaOps/Termination/Helpers/SetVariableHelpers.lean
+++ b/lean/SATGame/FormulaOps/Termination/Helpers/SetVariableHelpers.lean
@@ -1,0 +1,232 @@
+import Batteries.Data.List.Basic
+import Batteries.Tactic.Init
+import Mathlib.Tactic.Push
+import SATGame.Boolean.Literal
+import SATGame.FormulaOps.FormulaExt
+import SATGame.FormulaOps.Termination.Nonterminal
+import SATGame.Util.List
+
+/-!
+# Set Variable Helper Functions
+
+Complex utility theorems for variable assignment termination proofs.
+
+This module contains complex helper functions extracted from SetVariable.lean
+to improve code organization and readability.
+
+These helpers support the main termination proof by providing:
+- Basic clause processing utilities
+- Properties of satisfied clauses under variable assignment
+- Core filtering and counting theorems
+-/
+
+-- Basic helper: When a clause is satisfied, processClauseForVariableAssignment returns none
+theorem processClause_satisfied_returns_none {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) (value : Bool)
+    (h_satisfied : Clause.satisfiedBy clause var value = true) :
+    processClauseForVariableAssignment clause var value = none := by
+  unfold processClauseForVariableAssignment
+  rw [if_pos h_satisfied]
+
+-- Basic helper: When a clause is not satisfied, processClauseForVariableAssignment returns a clause without the variable
+theorem processClause_unsatisfied_removes_variable {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) (value : Bool)
+    (_h_contains : Clause.containsVariable clause var = true)
+    (h_not_satisfied : Clause.satisfiedBy clause var value = false) :
+    ∃ result_clause, processClauseForVariableAssignment clause var value = some result_clause ∧
+    Clause.containsVariable result_clause var = false := by
+  unfold processClauseForVariableAssignment
+  rw [if_neg (by
+    intro h_true
+    rw [h_true] at h_not_satisfied
+    cases h_not_satisfied
+  )]
+
+  -- The filtered clause is our witness
+  let filtered_clause := clause.filter fun lit => ¬(lit.containsVariable var)
+
+  -- Provide the existential witness
+  apply Exists.intro filtered_clause
+
+  constructor
+  · rfl
+  · unfold Clause.containsVariable
+    rw [List.any_eq_false]
+    intro lit h_lit_in_filtered
+    rw [List.mem_filter] at h_lit_in_filtered
+    obtain ⟨h_lit_in_orig, h_not_contains_var⟩ := h_lit_in_filtered
+    have h_decide : decide (¬lit.containsVariable var = true) = true := h_not_contains_var
+    rw [decide_eq_true_iff] at h_decide
+    exact h_decide
+
+-- Helper: Combined theorem - processClauseForVariableAssignment removes the variable from the clause
+theorem processClause_removes_variable {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) (value : Bool)
+    (h_contains : Clause.containsVariable clause var = true) :
+    processClauseForVariableAssignment clause var value = none ∨
+    (∃ result_clause, processClauseForVariableAssignment clause var value = some result_clause ∧
+     Clause.containsVariable result_clause var = false) := by
+  by_cases h_satisfied : Clause.satisfiedBy clause var value = true
+  · left
+    exact processClause_satisfied_returns_none clause var value h_satisfied
+  · right
+    have h_not_satisfied : Clause.satisfiedBy clause var value = false := by
+      by_cases h : Clause.satisfiedBy clause var value = false
+      · exact h
+      · exfalso
+        have h_bool : Clause.satisfiedBy clause var value = true ∨ Clause.satisfiedBy clause var value = false := by
+          cases Clause.satisfiedBy clause var value <;> simp
+        cases h_bool with
+        | inl h_true => exact h_satisfied h_true
+        | inr h_false => exact h h_false
+    exact processClause_unsatisfied_removes_variable clause var value h_contains h_not_satisfied
+
+-- Helper: Core theorem about filtering removing elements
+theorem filter_removes_element_strict {α : Type} (l : List α) (p : α → Bool) (x : α)
+    (h_mem : x ∈ l) (h_not_mem : x ∉ l.filter p) :
+    (l.filter p).length < l.length := by
+  have h_split : l.length = (l.filter p).length + (l.filter (fun a => ¬p a)).length := by
+    rw [← List.countP_eq_length_filter, ← List.countP_eq_length_filter]
+    exact List.length_eq_countP_add_countP p
+
+  have h_p_false : p x = false := by
+    by_contra h_contra
+    cases h : p x with
+    | false => contradiction
+    | true =>
+      have h_in : x ∈ l.filter p := by
+        rw [List.mem_filter]
+        exact ⟨h_mem, h⟩
+      exact h_not_mem h_in
+
+  have h_in_complement : x ∈ l.filter (fun a => ¬p a) := by
+    rw [List.mem_filter]
+    constructor
+    · exact h_mem
+    · simp [h_p_false]
+
+  have h_pos : 0 < (l.filter (fun a => ¬p a)).length := by
+    by_contra h_not_pos
+    have h_zero : (l.filter (fun a => ¬p a)).length = 0 := Nat.eq_zero_of_not_pos h_not_pos
+    have h_empty : l.filter (fun a => ¬p a) = [] := List.length_eq_zero_iff.mp h_zero
+    rw [h_empty] at h_in_complement
+    exact List.not_mem_nil h_in_complement
+
+  rw [h_split]
+  exact Nat.lt_add_of_pos_right h_pos
+
+-- Helper: When a literal contains a variable, it gets filtered out
+theorem literal_with_var_filtered_out {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) (lit : Literal Var)
+    (_h_lit_mem : List.Mem lit clause) (h_lit_has_var : lit.containsVariable var = true) :
+    ¬List.Mem lit (clause.filter (fun l => ¬(l.containsVariable var))) := by
+  intro h_in_filtered
+  have h_mem_filter := List.mem_filter.mp h_in_filtered
+  obtain ⟨h_in_orig, h_not_contains⟩ := h_mem_filter
+  have h_decide_contra : decide (¬lit.containsVariable var = true) = true := h_not_contains
+  rw [decide_eq_true_iff] at h_decide_contra
+  rw [h_lit_has_var] at h_decide_contra
+  simp at h_decide_contra
+
+/--
+Helper theorem: If a clause survives processing when the original contained the variable,
+then the result doesn't contain the variable.
+
+This handles the case where `processClause_removes_variable` returns `some`.
+-/
+private theorem processed_clause_no_variable_when_original_contained {Var : Type} [DecidableEq Var]
+    (orig_clause : Clause Var) (clause : Clause Var) (var : Var) (value : Bool)
+    (h_orig_contains : Clause.containsVariable orig_clause var = true)
+    (h_process_result : processClauseForVariableAssignment orig_clause var value = some clause) :
+    Clause.containsVariable clause var = false := by
+  have h_or := processClause_removes_variable orig_clause var value h_orig_contains
+  cases h_or with
+  | inl h_none =>
+    -- Contradiction: processClause returned some but should return none
+    rw [h_none] at h_process_result
+    cases h_process_result
+  | inr h_some =>
+    -- Extract the result clause and its property
+    obtain ⟨result_clause, h_eq, h_no_var⟩ := h_some
+    rw [h_eq] at h_process_result
+    have h_clause_eq : result_clause = clause := by
+      cases h_process_result
+      rfl
+    rw [← h_clause_eq]
+    exact h_no_var
+
+/--
+Helper theorem: Filtered clauses don't contain the filtered variable.
+
+When a clause is processed by filtering out literals containing a variable,
+the result cannot contain that variable.
+-/
+private theorem filtered_clause_no_variable {Var : Type} [DecidableEq Var]
+    (orig_clause : Clause Var) (var : Var) :
+    Clause.containsVariable (orig_clause.filter (fun lit => ¬(lit.containsVariable var))) var = false := by
+  unfold Clause.containsVariable
+  rw [List.any_eq_false]
+  intro lit h_lit_in_filtered
+  rw [List.mem_filter] at h_lit_in_filtered
+  obtain ⟨_, h_not_contains_lit⟩ := h_lit_in_filtered
+  have h_decide : decide (¬lit.containsVariable var = true) = true := h_not_contains_lit
+  rw [decide_eq_true_iff] at h_decide
+  exact h_decide
+
+/--
+Helper theorem: If original clause doesn't contain the variable, process it accordingly.
+
+When the original clause doesn't contain the variable, either it gets satisfied and removed,
+or it gets filtered (but filtering doesn't change it since no literals contain the variable).
+-/
+private theorem process_clause_when_no_variable {Var : Type} [DecidableEq Var]
+    (orig_clause : Clause Var) (clause : Clause Var) (var : Var) (value : Bool)
+    (h_process_result : processClauseForVariableAssignment orig_clause var value = some clause) :
+    Clause.containsVariable clause var = false := by
+  unfold processClauseForVariableAssignment at h_process_result
+  by_cases h_satisfied : Clause.satisfiedBy orig_clause var value = true
+  · -- Original clause is satisfied, so it should be removed (contradiction)
+    rw [if_pos h_satisfied] at h_process_result
+    cases h_process_result
+  · -- Original clause is not satisfied, so it gets filtered
+    rw [if_neg h_satisfied] at h_process_result
+    have h_clause_eq : clause = orig_clause.filter (fun lit => ¬(lit.containsVariable var)) := by
+      cases h_process_result
+      rfl
+    rw [h_clause_eq]
+    exact filtered_clause_no_variable orig_clause var
+
+/--
+**Main Property**: After setting a variable, no clause in the result contains that variable.
+
+This is a key invariant of variable assignment: once a variable is set, it's completely
+eliminated from the formula. Clauses are either:
+1. **Satisfied and removed** (if they contained a literal that became true)
+2. **Filtered** (literals containing the variable are removed)
+
+In both cases, the variable no longer appears in any remaining clause.
+
+## Proof Strategy
+
+1. Extract the original clause that produced the result clause
+2. **Case 1**: Original contained the variable → use `processClause_removes_variable`
+3. **Case 2**: Original didn't contain the variable → filtering preserves this property
+-/
+theorem setVariable_removes_variable {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool) (clause : Clause Var)
+    (h_clause_in_result : List.Mem clause (formula.setVariable var value)) :
+    Clause.containsVariable clause var = false := by
+  -- Extract the original clause that produced this result clause
+  unfold Formula.setVariable at h_clause_in_result
+  have h_exists : ∃ orig_clause, List.Mem orig_clause formula ∧ processClauseForVariableAssignment orig_clause var value = some clause := by
+    exact List.mem_filterMap.mp h_clause_in_result
+  let ⟨orig_clause, h_orig_mem, h_process_result⟩ := h_exists
+
+  -- Case analysis: did the original clause contain the variable?
+  cases h_bool : Clause.containsVariable orig_clause var with
+  | true =>
+    -- Case 1: Original contained the variable
+    exact processed_clause_no_variable_when_original_contained orig_clause clause var value h_bool h_process_result
+  | false =>
+    -- Case 2: Original didn't contain the variable
+    exact process_clause_when_no_variable orig_clause clause var value h_process_result

--- a/lean/SATGame/FormulaOps/Termination/Main.lean
+++ b/lean/SATGame/FormulaOps/Termination/Main.lean
@@ -212,12 +212,6 @@ def iterateStrategy {Var : Type} [DecidableEq Var]
     match strategy f with
     | .Terminal _ => f
     | .Continue op _ => f.applyOp op
--- TODO: Prove that nonterminal formulas always have applicable operations
--- theorem nonterminal_has_applicable_operation {Var : Type} [DecidableEq Var]
---     (formula : Formula Var) (h_nt : formula.isNonterminal = true) :
---     ∃ op : FormulaOp Var, op.IsApplicable formula
-
--- With the new StrategyResult approach, the shift property becomes much simpler!
 
 -- Key observation: One step of iteration equals the strategy result
 lemma iterateStrategy_one_step {Var : Type} [DecidableEq Var]
@@ -261,8 +255,6 @@ lemma iterateStrategy_shift_equality {Var : Type} [DecidableEq Var]
     -- After unfolding, both sides should be identical
     rw [ih]
 
--- Note: We're removing the complex shift lemma and using bounded iteration instead
--- This eliminates the dependent type issues we were struggling with
 
 /--
 **Core Iteration Shift Lemma**: The mathematical heart of the termination proof.
@@ -371,17 +363,12 @@ theorem every_valid_strategy_terminates_quickly {Var : Type} [DecidableEq Var] :
     ∀ (formula : Formula Var) (strategy : Strategy Var),
     WellFormedStrategy strategy →
     (iterateStrategy formula strategy formula.countLiterals).isTerminal = true := by
-  -- RESTRUCTURED APPROACH: Use well-founded induction on formulas
   intro formula
-  -- Apply well-founded induction on the literal count ordering
   apply HasLowerLiteralCount_wellFounded.induction formula
   intro f ih strategy h_wf
-  -- ih gives us: ∀ g with fewer literals than f, the property holds for g
 
-  -- First check if f has 0 literals (base case)
   by_cases h_zero : f.countLiterals = 0
-  · -- Case: f has 0 literals
-    -- A formula with 0 literals must be terminal
+  · -- Base case: 0 literals implies terminal
     -- The key insight: use an existing helper theorem
     have h_terminal : f.isTerminal = true := by
       -- If countLiterals = 0, then either f = [] or f has clauses with total length 0
@@ -415,27 +402,20 @@ theorem every_valid_strategy_terminates_quickly {Var : Type} [DecidableEq Var] :
         left  -- Choose the first option: head.isEmpty = true
         exact h_clause_empty
 
-    -- Now show the main goal: (iterateStrategy f strategy f.countLiterals).isTerminal = true
-    rw [h_zero]  -- This rewrites f.countLiterals to 0
-    simp [iterateStrategy]  -- iterateStrategy f strategy 0 = f
+    rw [h_zero]
+    simp [iterateStrategy]
     exact h_terminal
 
-  · -- Case: f has > 0 literals
-    -- We need to show: (iterateStrategy f strategy f.countLiterals).isTerminal = true
-    -- Strategy: check what the strategy says about f
+  · -- Inductive case: f has > 0 literals
     match h_strat : strategy f with
     | .Terminal h_f_terminal =>
-      -- Strategy says f is terminal
-      -- Then iterateStrategy will detect this and stop at any step
-      -- We need a lemma: if formula is terminal, iterateStrategy preserves it
+      -- If f is terminal, iteration preserves it
       have h_iterate_preserves : ∀ n, (iterateStrategy f strategy n).isTerminal = true := by
         intro n
         induction n with
         | zero => simp [iterateStrategy]; exact h_f_terminal
         | succ k ih_k =>
           simp [iterateStrategy]
-          -- The match will see that (iterateStrategy f strategy k) is terminal
-          -- So it returns the terminal formula unchanged
           have h_k_terminal : (iterateStrategy f strategy k).isTerminal = true := ih_k
           -- When a formula is terminal, strategy should return Terminal (by well-formedness)
           have ⟨h_proof, h_eq⟩ := (h_wf (iterateStrategy f strategy k)).1 h_k_terminal
@@ -471,17 +451,10 @@ theorem every_valid_strategy_terminates_quickly {Var : Type} [DecidableEq Var] :
       have ih_result := ih (f.applyOp op) h_wf_rel strategy h_wf
       -- ih_result : (iterateStrategy (f.applyOp op) strategy (f.applyOp op).countLiterals).isTerminal = true
 
-      -- Now we need to connect this to iterating on f for f.countLiterals steps
-      -- Key insight: f.countLiterals > (f.applyOp op).countLiterals
-      -- So after 1 step on f, we have enough remaining steps
+      -- Since (f.applyOp op).countLiterals < f.countLiterals,
+      -- we have enough steps for termination
 
-      -- We need to show: (iterateStrategy f strategy f.countLiterals).isTerminal = true
-      -- Key insight: after 1 step, we get (f.applyOp op) which needs ≤ (f.applyOp op).countLiterals steps
-      -- Since f.countLiterals > (f.applyOp op).countLiterals, we have enough steps
-
-      -- First, let's understand what happens in the first step
       have h_positive : f.countLiterals > 0 := by
-        -- f has > 0 literals (from h_zero)
         push_neg at h_zero
         exact Nat.pos_of_ne_zero h_zero
 
@@ -864,8 +837,6 @@ noncomputable def any_valid_operation_list_terminates_within_bound {Var : Type} 
         push_neg at h_term_exists
         have h_ops_bound : ops.length ≤ min ops.length formula.countLiterals := by
           rw [Nat.min_eq_left h_short_ops]
-        -- h_term_exists now provides exactly what we need:
-        -- ∀ i ≤ ops.length, ¬(formula.applyOps (ops.take i)).isTerminal = true
         exact TerminationSearchResult.Exhausted ops.length h_ops_bound rfl h_term_exists
     · -- Case: formula.countLiterals < ops.length, so min = formula.countLiterals
       push_neg at h_short_ops
@@ -892,23 +863,18 @@ noncomputable def any_valid_operation_list_terminates_within_bound {Var : Type} 
         -- Then termination is forced at formula.countLiterals
         push_neg at h_early_term
         have h_formula_bound : formula.countLiterals ≤ min ops.length formula.countLiterals := by
-          -- Since formula.countLiterals < ops.length, min = formula.countLiterals
           rw [Nat.min_eq_right (Nat.le_of_lt h_formula_lt)]
         exact TerminationSearchResult.Found formula.countLiterals h_formula_bound (by
-                 -- Since no early termination up to formula.countLiterals,
-                 -- we can apply literal_count_progression
                  have h_literal_decrease : (formula.applyOps (ops.take formula.countLiterals)).countLiterals ≤ formula.countLiterals - formula.countLiterals := by
                    apply literal_count_progression
                    · exact Nat.le_of_lt h_formula_lt
                    · exact h_valid
                    · exact h_early_term
 
-                 -- This gives us literal count = 0
                  have h_zero_literals : (formula.applyOps (ops.take formula.countLiterals)).countLiterals = 0 := by
                    rw [Nat.sub_self] at h_literal_decrease
                    exact Nat.eq_zero_of_le_zero h_literal_decrease
 
-                 -- Apply zero_literals_terminal
                  exact zero_literals_terminal (formula.applyOps (ops.take formula.countLiterals)) h_zero_literals)
 
 
@@ -918,37 +884,18 @@ theorem any_valid_operation_list_terminates_or_exhausts {Var : Type} [DecidableE
     (h_valid : ∀ i (h_bound : i < ops.length), (ops.get ⟨i, h_bound⟩).IsApplicable (formula.applyOps (ops.take i))) :
     (∃ k ≤ ops.length, (formula.applyOps (ops.take k)).isTerminal = true) ∨
     (ops.length ≤ formula.countLiterals ∧ ¬(formula.applyOps ops).isTerminal = true) := by
-  -- This corollary follows from the main theorem through logical case analysis
-  -- The mathematical insight: either early termination or bounded exhaustion
-
-  -- Apply the main theorem to get our fundamental result
   have result := any_valid_operation_list_terminates_within_bound formula ops h_valid
-
-  -- The main theorem now gives us a TerminationSearchResult
-  -- We need to derive our specific disjunctive conclusion
 
   cases result with
   | Found k h_k_bound h_terminal =>
-    -- Case: termination found at position k
-    -- Check if this satisfies the corollary's first disjunct: k ≤ ops.length
     have h_k_le_ops : k ≤ ops.length := Nat.le_trans h_k_bound (Nat.min_le_left _ _)
-    -- We have termination, so we return the first disjunct
     exact Or.inl ⟨k, h_k_le_ops, h_terminal⟩
   | Exhausted k h_k_bound h_eq h_no_term =>
-    -- Case: exhaustion without early termination (k = ops.length)
-    -- We prove the second disjunct: (ops.length ≤ formula.countLiterals ∧ ¬(formula.applyOps ops).isTerminal = true)
-
-    -- First part: ops.length ≤ formula.countLiterals
     have h_length_bound : ops.length ≤ formula.countLiterals := by
       rw [←h_eq]
       exact Nat.le_trans h_k_bound (Nat.min_le_right _ _)
 
-    -- Second part: ¬(formula.applyOps ops).isTerminal = true
     have h_final_nonterm : ¬(formula.applyOps ops).isTerminal = true := by
-      -- From h_no_term: ∀ i ≤ k, ¬(formula.applyOps (ops.take i)).isTerminal = true
-      -- Since k = ops.length, we have ∀ i ≤ ops.length, ¬(formula.applyOps (ops.take i)).isTerminal = true
-      -- In particular, for i = ops.length: ¬(formula.applyOps (ops.take ops.length)).isTerminal = true
-      -- Since ops.take ops.length = ops, this gives us ¬(formula.applyOps ops).isTerminal = true
       have h_at_length : ¬(formula.applyOps (ops.take ops.length)).isTerminal = true := by
         apply h_no_term
         rw [h_eq]

--- a/lean/SATGame/FormulaOps/Termination/Main.lean
+++ b/lean/SATGame/FormulaOps/Termination/Main.lean
@@ -1,0 +1,960 @@
+import Mathlib.Data.List.TakeDrop
+import SATGame.FormulaOps.FormulaOps
+import SATGame.FormulaOps.Termination.Nonterminal
+import SATGame.FormulaOps.Termination.RemoveClause
+import SATGame.FormulaOps.Termination.SetVariable
+import SATGame.Util.List
+
+/-!
+# Main Termination Theorem
+
+Establishes the central result: **formula operations always terminate**.
+
+## Theorem Hierarchy
+
+1. **operation_decreases_literalCount**: Each valid operation on a nonterminal formula
+   strictly decreases the literal count
+2. **HasLowerLiteralCount_wellFounded**: The literal count ordering is well-founded
+   (no infinite descending chains)
+3. **operations_bounded_by_literalCount**: Any sequence of valid operations is bounded
+   by the initial literal count
+
+Together, these theorems prove that sequences of formula operations must terminate.
+-/
+
+/--
+Relation defining when one formula has strictly fewer literals than another.
+
+This serves as our termination measure: every valid operation on a nonterminal
+formula produces a formula with a lower literal count, and natural number ordering
+is well-founded.
+-/
+def HasLowerLiteralCount {Var : Type} : Formula Var → Formula Var → Prop :=
+  InvImage (· < ·) Formula.countLiterals
+
+/--
+The literal count relation is well-founded.
+
+This establishes that there are no infinite descending chains of formulas under
+the literal count ordering. This technical property is used to prove that
+sequences of operations must terminate.
+-/
+theorem HasLowerLiteralCount_wellFounded {Var : Type} :
+    WellFounded (HasLowerLiteralCount : Formula Var → Formula Var → Prop) := by
+  apply InvImage.wf
+  exact Nat.lt_wfRel.wf
+
+/--
+**Master Termination Result**: Every valid operation decreases literal count.
+
+This theorem unifies all termination proofs, showing that regardless of which
+operation is applied (variable assignment or clause removal), the literal count
+strictly decreases for any nonterminal formula.
+-/
+theorem operation_decreases_literalCount {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (op : FormulaOp Var)
+    (h_nonterminal : formula.isNonterminal = true)
+    (h_applicable : op.IsApplicable formula) :
+    (formula.applyOp op).countLiterals < formula.countLiterals := by
+  cases op with
+  | SetVariable var value =>
+    -- Apply setVariable termination theorem
+    apply setVariable_decreases_literalCount formula var value h_nonterminal
+    -- The goal is: (List.any formula fun clause => Clause.containsVariable clause var) = true
+    -- We have h_applicable : (FormulaOp.SetVariable var value).IsApplicable formula
+    -- which unfolds to: formula.containsVariable var = true
+    -- These are exactly the same after unfolding definitions
+    unfold FormulaOp.IsApplicable at h_applicable
+    exact h_applicable
+  | RemoveClause index =>
+    -- Apply removeClause termination theorem
+    apply removeClause_decreases_literalCount formula index h_nonterminal
+    -- Need to prove index is valid (follows from IsApplicable)
+    unfold FormulaOp.IsApplicable at h_applicable
+    simp at h_applicable
+    exact h_applicable
+
+/-- Apply a list of operations sequentially to a formula -/
+def Formula.applyOps {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops : List (FormulaOp Var)) : Formula Var :=
+  ops.foldl Formula.applyOp formula
+
+/-- Sequential application of operations: applying op::rest equals applying op then rest -/
+lemma Formula.applyOps_cons {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (op : FormulaOp Var) (rest : List (FormulaOp Var)) :
+    formula.applyOps (op :: rest) = (formula.applyOp op).applyOps rest := by
+  simp [Formula.applyOps, List.foldl_cons]
+
+/-- Taking first n+1 operations from op::rest and applying them is equivalent to
+    applying op then taking first n operations from rest -/
+lemma applyOps_take_cons_succ {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (op : FormulaOp Var) (rest : List (FormulaOp Var)) (n : Nat) :
+    formula.applyOps ((op :: rest).take (n + 1)) = (formula.applyOp op).applyOps (rest.take n) := by
+  -- Direct simplification using list properties
+  simp [Formula.applyOps, List.foldl_cons, List.take_cons]
+
+/-- Applying operations from two lists sequentially is equivalent to applying the concatenated list -/
+lemma Formula.applyOps_append {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops1 ops2 : List (FormulaOp Var)) :
+    formula.applyOps (ops1 ++ ops2) = (formula.applyOps ops1).applyOps ops2 := by
+  unfold Formula.applyOps
+  rw [List.foldl_append]
+
+/-- Empty formulas remain empty under any sequence of operations -/
+lemma empty_formula_applyOps {Var : Type} [DecidableEq Var] (ops : List (FormulaOp Var)) :
+    Formula.applyOps ([] : Formula Var) ops = [] := by
+  induction ops with
+  | nil =>
+    -- Base case: no operations applied to empty formula
+    simp [Formula.applyOps]
+  | cons op rest ih =>
+    -- Inductive case: apply operation then rest of operations
+    rw [Formula.applyOps_cons]
+    -- Goal: (Formula.applyOp ([] : Formula Var) op).applyOps rest = []
+    -- First show Formula.applyOp ([] : Formula Var) op = []
+    have h_op_empty : Formula.applyOp ([] : Formula Var) op = [] := by
+      cases op with
+      | SetVariable var value =>
+        -- Empty formula setVariable returns empty
+        simp [Formula.applyOp, Formula.setVariable, List.filterMap_nil]
+      | RemoveClause index =>
+        -- Empty formula removeClause returns empty
+        simp [Formula.applyOp, Formula.removeClause, List.eraseIdx_nil]
+    -- Now apply inductive hypothesis
+    rw [h_op_empty]
+    exact ih
+
+/-- Empty clauses cannot be satisfied by any variable assignment -/
+lemma empty_clause_not_satisfied {Var : Type} [DecidableEq Var] (var : Var) (value : Bool) :
+  ¬Clause.satisfiedBy ([] : Clause Var) var value := by
+  unfold Clause.satisfiedBy
+  simp [List.any_nil]
+
+/-- Processing an empty clause for variable assignment always returns an empty clause -/
+lemma processClause_preserves_empty {Var : Type} [DecidableEq Var] (var : Var) (value : Bool) :
+  processClauseForVariableAssignment ([] : Clause Var) var value = some [] := by
+  unfold processClauseForVariableAssignment
+  -- Use our lemma that empty clauses are never satisfied
+  have h_not_satisfied := empty_clause_not_satisfied var value
+  simp [h_not_satisfied, List.filter_nil]
+
+/-- setVariable preserves the existence of empty clauses -/
+lemma setVariable_preserves_hasEmptyClause {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool) :
+    formula.hasEmptyClause = true → (formula.setVariable var value).hasEmptyClause = true := by
+  intro h_has_empty
+  unfold Formula.hasEmptyClause at h_has_empty ⊢
+  unfold Formula.setVariable
+  -- We have an empty clause in the original formula
+  rw [List.any_eq_true] at h_has_empty
+  obtain ⟨empty_clause, h_in_formula, h_isEmpty⟩ := h_has_empty
+  -- Show that the result of setVariable also has an empty clause
+  rw [List.any_eq_true]
+  -- Since the empty clause gets mapped to some [], it appears in the filterMap result
+  have h_process_result := processClause_preserves_empty var value
+  have h_empty_eq : empty_clause = [] := by
+    unfold Clause.isEmpty at h_isEmpty
+    rw [List.isEmpty_iff] at h_isEmpty
+    exact h_isEmpty
+  -- The empty clause maps to some [] and appears in the result
+  use []
+  constructor
+  · -- Show [] is in the filterMap result
+    rw [List.mem_filterMap]
+    use empty_clause
+    constructor
+    · exact h_in_formula
+    · rw [h_empty_eq]
+      exact h_process_result
+  · -- Show [] is empty
+    simp [Clause.isEmpty]
+
+
+-- Strategy-Based Termination: Any valid strategy reaches terminal within literal count bound
+
+/--
+Result of applying a strategy to a formula.
+Either the formula is terminal (game over) or we get an operation to continue.
+This avoids dependent types in the recursion by making the strategy handle the branching.
+-/
+inductive StrategyResult (Var : Type) [DecidableEq Var] (f : Formula Var) where
+  | Terminal : f.isTerminal = true → StrategyResult Var f
+  | Continue : (op : FormulaOp Var) → op.IsApplicable f → StrategyResult Var f
+
+/--
+A strategy is a function that returns a result for any formula.
+The result either proves the formula is terminal or provides a valid operation.
+This captures the game-theoretic notion of "how to play" while avoiding dependent type issues.
+-/
+def Strategy (Var : Type) [DecidableEq Var] :=
+  (f : Formula Var) → StrategyResult Var f
+
+/--
+A strategy is well-formed if it respects the terminal/nonterminal distinction:
+- Returns Terminal when formula is terminal
+- Returns Continue when formula is nonterminal
+-/
+def WellFormedStrategy {Var : Type} [DecidableEq Var] (strategy : Strategy Var) : Prop :=
+  ∀ f : Formula Var,
+    (f.isTerminal = true → ∃ h, strategy f = .Terminal h) ∧
+    (f.isNonterminal = true → ∃ op h, strategy f = .Continue op h)
+
+/--
+Apply a strategy iteratively for n steps, stopping early if the formula becomes terminal.
+This models playing a game according to a strategy until either terminal state or step limit.
+With the new StrategyResult type, there's no dependent if-then-else!
+-/
+def iterateStrategy {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (strategy : Strategy Var) : Nat → Formula Var
+  | 0 => formula
+  | n+1 =>
+    let f := iterateStrategy formula strategy n
+    match strategy f with
+    | .Terminal _ => f
+    | .Continue op _ => f.applyOp op
+-- TODO: Prove that nonterminal formulas always have applicable operations
+-- theorem nonterminal_has_applicable_operation {Var : Type} [DecidableEq Var]
+--     (formula : Formula Var) (h_nt : formula.isNonterminal = true) :
+--     ∃ op : FormulaOp Var, op.IsApplicable formula
+
+-- With the new StrategyResult approach, the shift property becomes much simpler!
+
+-- Key observation: One step of iteration equals the strategy result
+lemma iterateStrategy_one_step {Var : Type} [DecidableEq Var]
+    (f : Formula Var) (strategy : Strategy Var) :
+    iterateStrategy f strategy 1 =
+      match strategy f with
+      | .Terminal _ => f
+      | .Continue op _ => f.applyOp op := by
+  simp [iterateStrategy]
+
+-- Key recursive equality: shifting iteration by one step
+lemma iterateStrategy_shift_equality {Var : Type} [DecidableEq Var]
+    (f : Formula Var) (strategy : Strategy Var) (op : FormulaOp Var)
+    (h_op_applicable : op.IsApplicable f) (n : Nat)
+    (h_strat : strategy f = .Continue op h_op_applicable) :
+    iterateStrategy f strategy (n + 1) = iterateStrategy (f.applyOp op) strategy n := by
+  -- Key insight: both sides follow the same recursive pattern after the first step
+  induction n with
+  | zero =>
+    -- Base case: n = 0
+    -- LHS: iterateStrategy f strategy 1 = (match strategy f with | Terminal => f | Continue op => f.applyOp op)
+    -- RHS: iterateStrategy (f.applyOp op) strategy 0 = f.applyOp op
+    -- Since strategy f = Continue op, LHS = f.applyOp op = RHS
+    rw [iterateStrategy_one_step]
+    rw [h_strat]
+    simp [iterateStrategy]
+  | succ k ih =>
+    -- Inductive case: n = k + 1
+    -- Use the recursive definition of iterateStrategy directly
+    -- LHS: iterateStrategy f strategy (k + 2)
+    -- RHS: iterateStrategy (f.applyOp op) strategy (k + 1)
+
+    -- Unfold LHS: iterateStrategy f strategy (k + 2) = apply strategy to (iterateStrategy f strategy (k + 1))
+    -- By IH: iterateStrategy f strategy (k + 1) = iterateStrategy (f.applyOp op) strategy k
+    -- So LHS = apply strategy to (iterateStrategy (f.applyOp op) strategy k)
+
+    -- Unfold RHS: iterateStrategy (f.applyOp op) strategy (k + 1) = apply strategy to (iterateStrategy (f.applyOp op) strategy k)
+
+    -- Therefore LHS = RHS
+    unfold iterateStrategy
+    -- After unfolding, both sides should be identical
+    rw [ih]
+
+-- Note: We're removing the complex shift lemma and using bounded iteration instead
+-- This eliminates the dependent type issues we were struggling with
+
+/--
+**Core Iteration Shift Lemma**: The mathematical heart of the termination proof.
+
+If a formula f takes one step to become g via a strategy, and g terminates within n steps,
+then f terminates within n+1 steps. This connects the well-founded induction hypothesis
+to the main goal without dependent type complications.
+-/
+lemma iterateStrategy_shift_step {Var : Type} [DecidableEq Var]
+    (f : Formula Var) (strategy : Strategy Var) (op : FormulaOp Var)
+    (h_op_applicable : op.IsApplicable f) (n : Nat)
+    (h_strat : strategy f = .Continue op h_op_applicable)
+    (h_terminal : (iterateStrategy (f.applyOp op) strategy n).isTerminal = true) :
+    (iterateStrategy f strategy (n + 1)).isTerminal = true := by
+  -- Key insight: We need to show that iterating from f for n+1 steps is terminal
+  -- We know that iterating from (f.applyOp op) for n steps is terminal
+  -- The connection is through the recursive structure of iterateStrategy
+
+  -- First, let's understand what happens step by step:
+  -- iterateStrategy f strategy (n + 1) applies the strategy to the result of n steps
+  -- But the result after n steps from f should be the same as after n-1 steps from f.applyOp op
+
+  -- Use induction on n to establish the recursive connection
+  induction n with
+  | zero =>
+    -- Base case: n = 0
+    -- Goal: (iterateStrategy f strategy 1).isTerminal = true
+    -- Given: (iterateStrategy (f.applyOp op) strategy 0).isTerminal = true
+    -- Since iterateStrategy ... 0 = identity, we have: (f.applyOp op).isTerminal = true
+
+    -- Simplify the hypothesis: iterateStrategy (f.applyOp op) strategy 0 = f.applyOp op
+    have h_identity : iterateStrategy (f.applyOp op) strategy 0 = f.applyOp op := by
+      simp [iterateStrategy]
+    rw [h_identity] at h_terminal
+    -- Now h_terminal : (f.applyOp op).isTerminal = true
+
+    -- Show the goal using the one-step lemma
+    rw [iterateStrategy_one_step]
+    rw [h_strat]
+    -- Goal becomes: (f.applyOp op).isTerminal = true
+    exact h_terminal
+
+  | succ k ih =>
+    -- Inductive case: n = k + 1
+    -- Goal: (iterateStrategy f strategy (k + 2)).isTerminal = true
+    -- Given: (iterateStrategy (f.applyOp op) strategy (k + 1)).isTerminal = true
+
+    -- Use our shift equality lemma!
+    -- We know: iterateStrategy f strategy (k + 2) = iterateStrategy (f.applyOp op) strategy (k + 1)
+    rw [iterateStrategy_shift_equality f strategy op h_op_applicable (k + 1) h_strat]
+    -- Now the goal becomes: (iterateStrategy (f.applyOp op) strategy (k + 1)).isTerminal = true
+    -- This is exactly our hypothesis!
+    exact h_terminal
+
+/--
+Monotonicity of iteration: if a formula terminates in m steps, it also terminates in k steps for any k ≥ m.
+This is because once a formula becomes terminal, it stays terminal under further iterations.
+-/
+-- Simple monotonicity lemma - if formula terminates in m steps, it terminates in more steps
+lemma iterateStrategy_monotonic {Var : Type} [DecidableEq Var]
+    (f : Formula Var) (strategy : Strategy Var) (m k : Nat)
+    (h_wf : WellFormedStrategy strategy)
+    (h_le : m ≤ k)
+    (h_term : (iterateStrategy f strategy m).isTerminal = true) :
+    (iterateStrategy f strategy k).isTerminal = true := by
+  -- Express k = m + d and induct on d
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le h_le
+
+  -- Induction on d
+  induction d with
+  | zero =>
+    -- Base case: k = m + 0 = m
+    simp
+    exact h_term
+
+  | succ d ih =>
+    -- Inductive step: k = m + (d + 1) = (m + d) + 1
+    -- IH: (iterateStrategy f strategy (m + d)).isTerminal = true
+    -- Goal: (iterateStrategy f strategy (m + d + 1)).isTerminal = true
+
+    -- Let g = iterateStrategy f strategy (m + d)
+    let g := iterateStrategy f strategy (m + d)
+    have h_g_terminal : g.isTerminal = true := by
+      apply ih
+      simp [Nat.le_add_right]
+
+    -- Goal: (iterateStrategy f strategy (m + d + 1)).isTerminal = true
+    -- By definition: this is (iterateStrategy f strategy ((m + d) + 1))
+    simp [Nat.add_assoc] at *
+    simp [iterateStrategy]
+
+    -- Since g is terminal and strategy is well-formed, strategy g returns Terminal
+    have h_strat_terminal : ∃ h, strategy g = .Terminal h := by
+      exact (h_wf g).1 h_g_terminal
+
+    -- Extract the witness and apply
+    obtain ⟨h_proof, h_eq_strat⟩ := h_strat_terminal
+    rw [h_eq_strat]
+
+    -- Goal becomes: g.isTerminal = true
+    exact h_g_terminal
+
+-- Universal theorem: every well-formed strategy terminates within literal count bound
+-- This version avoids the complex shift property by using bounded iteration
+theorem every_valid_strategy_terminates_quickly {Var : Type} [DecidableEq Var] :
+    ∀ (formula : Formula Var) (strategy : Strategy Var),
+    WellFormedStrategy strategy →
+    (iterateStrategy formula strategy formula.countLiterals).isTerminal = true := by
+  -- RESTRUCTURED APPROACH: Use well-founded induction on formulas
+  intro formula
+  -- Apply well-founded induction on the literal count ordering
+  apply HasLowerLiteralCount_wellFounded.induction formula
+  intro f ih strategy h_wf
+  -- ih gives us: ∀ g with fewer literals than f, the property holds for g
+
+  -- First check if f has 0 literals (base case)
+  by_cases h_zero : f.countLiterals = 0
+  · -- Case: f has 0 literals
+    -- A formula with 0 literals must be terminal
+    -- The key insight: use an existing helper theorem
+    have h_terminal : f.isTerminal = true := by
+      -- If countLiterals = 0, then either f = [] or f has clauses with total length 0
+      -- In both cases, the formula is terminal
+      cases f with
+      | nil =>
+        -- Empty formula is terminal
+        unfold Formula.isTerminal
+        simp
+      | cons head tail =>
+        -- Non-empty formula with 0 literals must have an empty clause
+        -- Since countLiterals = sum of clause lengths = 0, at least one clause is empty
+        unfold Formula.countLiterals at h_zero
+        simp at h_zero
+        -- After simp, h_zero is a conjunction, extract the parts
+        have h_head_empty : head.length = 0 := by
+          -- h_zero gives us head = [] ∧ tail sum = 0
+          -- If head = [], then head.length = 0
+          have h_head_nil : head = [] := h_zero.1
+          rw [h_head_nil]
+          simp
+        -- An empty clause makes the formula terminal
+        have h_clause_empty : head.isEmpty = true := by
+          unfold Clause.isEmpty
+          rw [List.isEmpty_iff_length_eq_zero]
+          exact h_head_empty
+        -- So formula has empty clause and is terminal
+        unfold Formula.isTerminal Formula.hasEmptyClause
+        simp
+        -- Need to prove: head.isEmpty = true ∨ ∃ x ∈ tail, x.isEmpty = true
+        left  -- Choose the first option: head.isEmpty = true
+        exact h_clause_empty
+
+    -- Now show the main goal: (iterateStrategy f strategy f.countLiterals).isTerminal = true
+    rw [h_zero]  -- This rewrites f.countLiterals to 0
+    simp [iterateStrategy]  -- iterateStrategy f strategy 0 = f
+    exact h_terminal
+
+  · -- Case: f has > 0 literals
+    -- We need to show: (iterateStrategy f strategy f.countLiterals).isTerminal = true
+    -- Strategy: check what the strategy says about f
+    match h_strat : strategy f with
+    | .Terminal h_f_terminal =>
+      -- Strategy says f is terminal
+      -- Then iterateStrategy will detect this and stop at any step
+      -- We need a lemma: if formula is terminal, iterateStrategy preserves it
+      have h_iterate_preserves : ∀ n, (iterateStrategy f strategy n).isTerminal = true := by
+        intro n
+        induction n with
+        | zero => simp [iterateStrategy]; exact h_f_terminal
+        | succ k ih_k =>
+          simp [iterateStrategy]
+          -- The match will see that (iterateStrategy f strategy k) is terminal
+          -- So it returns the terminal formula unchanged
+          have h_k_terminal : (iterateStrategy f strategy k).isTerminal = true := ih_k
+          -- When a formula is terminal, strategy should return Terminal (by well-formedness)
+          have ⟨h_proof, h_eq⟩ := (h_wf (iterateStrategy f strategy k)).1 h_k_terminal
+          rw [h_eq]
+          exact h_k_terminal
+      exact h_iterate_preserves f.countLiterals
+
+    | .Continue op h_op_applicable =>
+      -- Strategy says to continue with operation op
+      -- By well-formedness, f must be nonterminal
+      have h_nonterminal : f.isNonterminal = true := by
+        by_contra h_not_nt
+        have h_terminal : f.isTerminal = true := by
+          unfold Formula.isNonterminal at h_not_nt
+          simp at h_not_nt
+          exact h_not_nt
+        have ⟨h_proof, h_eq⟩ := (h_wf f).1 h_terminal
+        rw [h_eq] at h_strat
+        -- This gives us Terminal = Continue, which is impossible
+        have : StrategyResult.Terminal h_proof = StrategyResult.Continue op h_op_applicable := h_strat
+        injection this
+
+      -- Operation decreases literal count
+      have h_decrease : (f.applyOp op).countLiterals < f.countLiterals :=
+        operation_decreases_literalCount f op h_nonterminal h_op_applicable
+
+      -- Apply IH to the smaller formula
+      have h_wf_rel : HasLowerLiteralCount (f.applyOp op) f := by
+        unfold HasLowerLiteralCount
+        exact h_decrease
+
+      -- The IH tells us (f.applyOp op) terminates within its literal count
+      have ih_result := ih (f.applyOp op) h_wf_rel strategy h_wf
+      -- ih_result : (iterateStrategy (f.applyOp op) strategy (f.applyOp op).countLiterals).isTerminal = true
+
+      -- Now we need to connect this to iterating on f for f.countLiterals steps
+      -- Key insight: f.countLiterals > (f.applyOp op).countLiterals
+      -- So after 1 step on f, we have enough remaining steps
+
+      -- We need to show: (iterateStrategy f strategy f.countLiterals).isTerminal = true
+      -- Key insight: after 1 step, we get (f.applyOp op) which needs ≤ (f.applyOp op).countLiterals steps
+      -- Since f.countLiterals > (f.applyOp op).countLiterals, we have enough steps
+
+      -- First, let's understand what happens in the first step
+      have h_positive : f.countLiterals > 0 := by
+        -- f has > 0 literals (from h_zero)
+        push_neg at h_zero
+        exact Nat.pos_of_ne_zero h_zero
+
+      -- So f.countLiterals = n + 1 for some n
+      have ⟨n, h_n⟩ : ∃ n, f.countLiterals = n + 1 := by
+        cases h_eq : f.countLiterals with
+        | zero => rw [h_eq] at h_positive; exact absurd h_positive (Nat.lt_irrefl 0)
+        | succ n => exact ⟨n, rfl⟩
+
+      -- After 1 step, we apply the operation
+      have h_first_step : iterateStrategy f strategy 1 = f.applyOp op := by
+        rw [iterateStrategy_one_step]
+        rw [h_strat]
+
+      -- We have (f.applyOp op).countLiterals < f.countLiterals = n + 1
+      -- So (f.applyOp op).countLiterals ≤ n
+      have h_bound : (f.applyOp op).countLiterals ≤ n := by
+        rw [h_n] at h_decrease
+        exact Nat.lt_succ_iff.mp h_decrease
+
+      -- The challenge: connect iterateStrategy f strategy (n+1) to the IH result
+      -- Without the shift property, we need a different approach
+      -- Key insight: We need a monotonicity lemma
+      -- Let's prove that if we have enough steps to terminate from a smaller formula,
+      -- then we have enough steps from the larger formula
+
+      -- We know: (iterateStrategy (f.applyOp op) strategy (f.applyOp op).countLiterals).isTerminal = true
+      -- We need: (iterateStrategy f strategy f.countLiterals).isTerminal = true
+
+      -- Since f.countLiterals = n + 1 and (f.applyOp op).countLiterals ≤ n
+      -- We have enough steps remaining after the first operation
+
+      -- The key insight: we need to connect the iteration steps
+      -- After 1 step from f, we get f.applyOp op (smaller formula)
+      -- The IH tells us this smaller formula terminates within its literal count
+      -- Since f.countLiterals = n+1 > (f.applyOp op).countLiterals, we have enough steps
+
+      -- The core insight: we need to prove that after 1 step on f,
+      -- the remaining iteration is equivalent to iterating on the smaller formula
+
+      -- We'll prove this by showing that the smaller formula terminates within our step budget
+      -- Since (f.applyOp op).countLiterals ≤ n and it terminates within its literal count,
+      -- it definitely terminates within n steps
+
+      -- Step 1: The smaller formula terminates within n steps (by monotonicity)
+      have h_smaller_terminates_in_n : (iterateStrategy (f.applyOp op) strategy n).isTerminal = true := by
+        apply iterateStrategy_monotonic (f.applyOp op) strategy (f.applyOp op).countLiterals n h_wf h_bound ih_result
+
+      -- Step 2: Show f terminates within n+1 steps using a direct approach
+      -- We'll use the fact that after 1 step from f, we get f.applyOp op
+      -- and we know f.applyOp op terminates within n steps
+
+      -- Key lemma: iterateStrategy f strategy (n+1) follows this pattern:
+      -- 1. Apply strategy to f → Continue op (given h_strat)
+      -- 2. Get f.applyOp op and continue for n more steps
+      -- 3. Since we know f.applyOp op terminates in ≤ n steps, we're done
+
+      -- The fundamental connection: Apply our core shift lemma
+      -- We have everything needed for iterateStrategy_shift_step:
+      -- - f and strategy
+      -- - op and h_op_applicable (from the Continue case)
+      -- - h_strat: strategy f = .Continue op h_op_applicable
+      -- - h_smaller_terminates_in_n: smaller formula terminates in n steps
+
+      -- Apply the shift lemma: we need to show f.countLiterals = n + 1 terminates
+      -- Our shift lemma shows (n + 1) terminates, and f.countLiterals = n + 1
+      rw [h_n] -- Replace f.countLiterals with n + 1
+      apply iterateStrategy_shift_step f strategy op h_op_applicable n h_strat h_smaller_terminates_in_n
+
+/-
+  -- OLD APPROACH (commented out for reference)
+  -- This is kept for historical reasons but will be removed once the new proof is complete
+  -- The old approach used regular induction on literal count which led to issues
+  -- accessing the well-founded induction hypothesis for arbitrary formulas
+-/
+
+-- Instance theorem: any specific well-formed strategy terminates within bound
+theorem any_valid_strategy_terminates_quickly {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (strategy : Strategy Var)
+    (h_wf : WellFormedStrategy strategy) :
+    (iterateStrategy formula strategy formula.countLiterals).isTerminal = true :=
+  every_valid_strategy_terminates_quickly formula strategy h_wf
+
+-- Existential version: if you need the witness explicitly
+theorem strategy_terminates_within_bound {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (strategy : Strategy Var)
+    (h_wf : WellFormedStrategy strategy) :
+    ∃ k ≤ formula.countLiterals, (iterateStrategy formula strategy k).isTerminal = true :=
+  ⟨formula.countLiterals, Nat.le_refl _, every_valid_strategy_terminates_quickly formula strategy h_wf⟩
+
+-- Helper lemmas for list operation proofs
+section ListOperationHelpers
+
+/--
+**Zero Literals Terminal**: A formula with zero literals is always terminal.
+
+This key lemma bridges literal count tracking to termination detection.
+A formula with 0 literals either has no clauses (satisfiable) or
+has empty clauses (unsatisfiable) - both are terminal states.
+-/
+lemma zero_literals_terminal {Var : Type} (formula : Formula Var)
+    (h_zero : formula.countLiterals = 0) : formula.isTerminal = true := by
+  -- Proof extracted from main theorem base case (lines 305-329)
+  -- If countLiterals = 0, then either f = [] or f has clauses with total length 0
+  -- In both cases, the formula is terminal
+  cases formula with
+  | nil =>
+    -- Empty formula is terminal
+    unfold Formula.isTerminal
+    simp
+  | cons head tail =>
+    -- Non-empty formula with 0 literals must have an empty clause
+    -- Since countLiterals = sum of clause lengths = 0, at least one clause is empty
+    unfold Formula.countLiterals at h_zero
+    simp at h_zero
+    -- After simp, h_zero is a conjunction, extract the parts
+    have h_head_empty : head.length = 0 := by
+      -- h_zero gives us head = [] ∧ tail sum = 0
+      -- If head = [], then head.length = 0
+      have h_head_nil : head = [] := h_zero.1
+      rw [h_head_nil]
+      simp
+    -- An empty clause makes the formula terminal
+    have h_clause_empty : head.isEmpty = true := by
+      unfold Clause.isEmpty
+      rw [List.isEmpty_iff_length_eq_zero]
+      exact h_head_empty
+    -- So formula has empty clause and is terminal
+    unfold Formula.isTerminal Formula.hasEmptyClause
+    simp
+    -- Need to prove: head.isEmpty = true ∨ ∃ x ∈ tail, x.isEmpty = true
+    left  -- Choose the first option: head.isEmpty = true
+    exact h_clause_empty
+
+/--
+**Literal Count Progression**: If we apply k operations without reaching a terminal state,
+the literal count decreases by at least k.
+
+This is the key lemma that tracks literal count through sequential operations,
+ensuring we can't exceed the original literal count bound.
+-/
+lemma literal_count_progression {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops : List (FormulaOp Var)) (k : Nat)
+    (h_k_bound : k ≤ ops.length)
+    (h_valid : ∀ i (h_bound : i < ops.length), (ops.get ⟨i, h_bound⟩).IsApplicable (formula.applyOps (ops.take i)))
+    (h_no_term : ∀ i < k, ¬(formula.applyOps (ops.take i)).isTerminal = true) :
+    (formula.applyOps (ops.take k)).countLiterals ≤ formula.countLiterals - k := by
+  -- Use induction on k to track literal count decrease
+  induction k with
+  | zero =>
+    -- Base case: k = 0, no operations applied
+    simp [Formula.applyOps]
+  | succ n ih =>
+    -- Inductive step: prove for n+1 given result for n
+    -- IH: (formula.applyOps (ops.take n)).countLiterals ≤ formula.countLiterals - n
+    -- Goal: (formula.applyOps (ops.take (n+1))).countLiterals ≤ formula.countLiterals - (n+1)
+
+    -- First, ensure we have the bounds we need
+    have h_n_bound : n ≤ ops.length := Nat.le_of_succ_le h_k_bound
+    have h_succ_bound : n < ops.length := Nat.lt_of_succ_le h_k_bound
+
+    -- Get the intermediate formula after n steps
+    let intermediate := formula.applyOps (ops.take n)
+
+    -- By h_no_term, intermediate is not terminal
+    have h_intermediate_nonterm : intermediate.isNonterminal = true := by
+      have h_not_term : ¬intermediate.isTerminal = true := h_no_term n (Nat.lt_succ_self n)
+      unfold Formula.isNonterminal
+      simp [h_not_term]
+
+    -- Get the operation to apply at step n
+    let op := ops.get ⟨n, h_succ_bound⟩
+
+    -- This operation is applicable to intermediate by h_valid
+    have h_op_applicable : op.IsApplicable intermediate := by
+      have h_valid_n := h_valid n h_succ_bound
+      -- Need to show that ops.get ⟨n, h_succ_bound⟩ is applicable to formula.applyOps (ops.take n)
+      -- These are definitionally equal by our definitions
+      exact h_valid_n
+
+    -- Applying op to intermediate decreases literal count
+    have h_decrease : (intermediate.applyOp op).countLiterals < intermediate.countLiterals :=
+      operation_decreases_literalCount intermediate op h_intermediate_nonterm h_op_applicable
+
+    -- Connect to our goal: applying n+1 operations equals applying n operations then one more
+    have h_take_succ : formula.applyOps (ops.take (n + 1)) = intermediate.applyOp op := by
+      -- This follows directly from the sequential nature of list operations
+      -- We can use our existing pattern similar to applyOps_take_cons_succ
+
+      -- Key insight: ops.take (n+1) can be split as ops.take n followed by ops[n]
+      -- This allows us to apply the sequential operation property
+
+      -- Apply Formula.applyOps definition and use list properties
+      unfold Formula.applyOps intermediate op
+
+      -- The goal is now: List.foldl Formula.applyOp formula (ops.take (n + 1)) =
+      --                  (List.foldl Formula.applyOp formula (ops.take n)).applyOp (ops.get ⟨n, h_succ_bound⟩)
+
+      -- This is exactly the pattern that List.foldl follows when processing one more element
+      -- We can establish this using the definition of take with successive indices
+
+      -- Use induction on the structure or establish via list lemmas
+      -- For now, this follows from the fundamental property of list foldl with consecutive takes
+      -- The mathematical pattern is exactly what our existing lemma applyOps_take_cons_succ establishes
+
+      -- The goal is: formula.applyOps (ops.take (n + 1)) = intermediate.applyOp op
+      -- where intermediate = formula.applyOps (ops.take n) and op = ops.get ⟨n, h_succ_bound⟩
+
+      -- We can prove this using the fundamental property of sequential list operations
+      -- The key insight: ops.take (n+1) is equivalent to taking n elements plus the (n+1)th element
+
+      -- For a direct proof, we'd use list properties like:
+      -- ops.take (n+1) = ops.take n ++ [ops.get n] (when n < ops.length)
+      -- And then applyOps distributes over concatenation
+
+      -- This follows from our existing pattern in applyOps_take_cons_succ
+      -- but requires adapting it to the general case rather than cons structure
+
+      -- The proof would unfold Formula.applyOps, use List.foldl properties,
+      -- and apply the list concatenation structure
+
+      -- The goal is to show: formula.applyOps (ops.take (n + 1)) = intermediate.applyOp op
+      -- where: intermediate = formula.applyOps (ops.take n) and op = ops.get ⟨n, h_succ_bound⟩
+
+      -- Key insight: this follows from properties of List.take and List.foldl
+      -- We need ops.take (n + 1) to include exactly ops.take n plus the element at position n
+
+      -- Since n < ops.length, we can decompose the list at position n
+      -- The take (n + 1) includes exactly the first n elements plus the nth element
+
+      unfold Formula.applyOps
+
+      -- Use the fact that take (n + 1) = take n + [ops[n]] when n < ops.length
+      -- This requires careful handling of list indexing and concatenation
+
+      -- We can use induction on the list structure or direct properties of take/foldl
+      -- The mathematical content is well-established in list theory
+
+      -- Apply list theory for take/foldl relationship
+      have h_take_structure : ops.take (n + 1) = ops.take n ++ [ops.get ⟨n, h_succ_bound⟩] := by
+        -- Use mathlib theorem: take_concat_get'
+        rw [← List.take_concat_get' ops n h_succ_bound]
+        -- Show that ops[n] = ops.get ⟨n, h_succ_bound⟩
+        congr
+
+      rw [h_take_structure]
+      simp only [List.foldl_append, List.foldl_cons, List.foldl_nil]
+
+    -- Apply the inductive hypothesis and operation decrease
+    rw [h_take_succ]
+
+    -- We know intermediate.countLiterals ≤ formula.countLiterals - n (by IH)
+    have h_ih_result : intermediate.countLiterals ≤ formula.countLiterals - n := by
+      apply ih h_n_bound
+      -- Need to show ∀ i < n, ¬(formula.applyOps (ops.take i)).isTerminal = true
+      intro i h_i_lt_n
+      exact h_no_term i (Nat.lt_trans h_i_lt_n (Nat.lt_succ_self n))
+
+    -- We know (intermediate.applyOp op).countLiterals < intermediate.countLiterals
+    -- Combined with IH: (intermediate.applyOp op).countLiterals < formula.countLiterals - n
+    -- We need: (intermediate.applyOp op).countLiterals ≤ formula.countLiterals - (n + 1)
+    -- This follows from natural number arithmetic with strict decrease
+    have h_strict_bound : (intermediate.applyOp op).countLiterals < formula.countLiterals - n :=
+      Nat.lt_of_lt_of_le h_decrease h_ih_result
+
+    -- For natural numbers: if x < y - n, then x ≤ y - (n + 1) when y > n
+    -- This is the key arithmetic step combining strict decrease with inductive bound
+    have h_final : (intermediate.applyOp op).countLiterals ≤ formula.countLiterals - (n + 1) := by
+      -- We have: (intermediate.applyOp op).countLiterals < intermediate.countLiterals ≤ formula.countLiterals - n
+      -- Goal: (intermediate.applyOp op).countLiterals ≤ formula.countLiterals - (n + 1)
+
+      -- The mathematical insight: strict decrease by 1 step + inductive bound gives us the stronger bound
+      -- If count decreases and we had bound ≤ original - n, then we get ≤ original - (n+1)
+      -- This is a fundamental arithmetic property for termination arguments
+
+      -- We have: (intermediate.applyOp op).countLiterals < formula.countLiterals - n
+      have h_strict_final : (intermediate.applyOp op).countLiterals < formula.countLiterals - n :=
+        Nat.lt_of_lt_of_le h_decrease h_ih_result
+
+      -- For natural numbers: if x < y - n, then x ≤ y - (n + 1) provided y ≥ n + 1
+      -- This follows from: x < y - n = (y - (n + 1)) + 1, so x ≤ y - (n + 1)
+
+      -- Simple approach: use the transitivity and properties of strict decrease
+      -- We know that each operation decreases by at least 1, so n+1 operations decrease by at least n+1
+      -- This is a fundamental property of our termination argument
+
+      -- The key insight: if x < intermediate ≤ original - n, then x ≤ original - (n+1)
+      -- This is because operations decrease count, and we compound the decreases
+
+      -- For practical purposes, this arithmetic follows from the core termination properties
+      -- and the inductive structure we've established
+
+      -- Natural number arithmetic: if x < y - n, then x ≤ y - (n+1)
+      -- Use the fact that strict inequality gives us the stronger bound
+      have h_le_pred : (intermediate.applyOp op).countLiterals ≤ (formula.countLiterals - n) - 1 := by
+        -- x < y implies x ≤ y - 1 for natural numbers
+        exact Nat.le_sub_one_of_lt h_strict_final
+      -- Show that (y - n) - 1 = y - (n + 1)
+      have h_sub_rearrange : (formula.countLiterals - n) - 1 = formula.countLiterals - (n + 1) := by
+        rw [← Nat.sub_sub]
+      -- Combine via transitivity
+      rw [← h_sub_rearrange]
+      exact h_le_pred
+
+    exact h_final
+
+end ListOperationHelpers
+
+-- Extension to finite operation sequences
+section ListOperations
+
+/-- Result type for termination search that explicitly carries semantic information -/
+inductive TerminationSearchResult {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops : List (FormulaOp Var)) : Type where
+  | Found (k : Nat) :
+      (h_bound : k ≤ min ops.length formula.countLiterals) →
+      (h_terminal : (formula.applyOps (ops.take k)).isTerminal = true) →
+      TerminationSearchResult formula ops
+  | Exhausted (k : Nat) :
+      (h_bound : k ≤ min ops.length formula.countLiterals) →
+      (h_eq : k = ops.length) →
+      (h_no_term : ∀ i ≤ k, ¬(formula.applyOps (ops.take i)).isTerminal = true) →
+      TerminationSearchResult formula ops
+
+noncomputable def any_valid_operation_list_terminates_within_bound {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops : List (FormulaOp Var))
+    (h_valid : ∀ i (h_bound : i < ops.length), (ops.get ⟨i, h_bound⟩).IsApplicable (formula.applyOps (ops.take i))) :
+    TerminationSearchResult formula ops := by
+  -- Strategy: Use helper lemmas to track literal count and detect termination
+  -- Key insight: Either we find termination early or literal count forces termination
+
+  -- Base case: if formula is already terminal
+  by_cases h_term_start : formula.isTerminal = true
+  · -- Case: formula is already terminal at step 0
+    exact TerminationSearchResult.Found 0 (by simp) (by simp [Formula.applyOps, h_term_start])
+  · -- Case: formula is nonterminal, so we track operations until termination
+
+    -- Key insight: Use bounded search up to min(ops.length, formula.countLiterals)
+    let bound := min ops.length formula.countLiterals
+
+    -- Search for first termination point within bound
+    -- This is a finite search since bound is finite
+    have h_bound_finite : bound ≤ ops.length ∧ bound ≤ formula.countLiterals := by
+      constructor
+      · -- bound ≤ ops.length
+        simp [bound]
+        exact Nat.min_le_left ops.length formula.countLiterals
+      · -- bound ≤ formula.countLiterals
+        simp [bound]
+        exact Nat.min_le_right ops.length formula.countLiterals
+
+    -- Core argument: Within bound steps, either:
+    -- 1. We find early termination, or
+    -- 2. Literal count reaches 0, forcing termination by zero_literals_terminal
+
+    -- For the implementation, we use the mathematical insight:
+    -- If we don't find early termination in bound steps, then by literal_count_progression,
+    -- the literal count would be ≤ original - bound ≤ original - formula.countLiterals = 0
+    -- By zero_literals_terminal, literal count 0 implies terminal
+
+    -- The detailed proof requires careful case analysis on the search process
+    -- This is exactly the pattern our helper lemmas were designed to support
+    by_cases h_short_ops : ops.length ≤ formula.countLiterals
+    · -- Case: ops.length ≤ formula.countLiterals, so min = ops.length
+      -- In this case, we need to check for termination up to ops.length
+      have h_bound_eq : bound = ops.length := by
+        simp [bound, Nat.min_eq_left h_short_ops]
+
+      -- Check if there's termination anywhere up to ops.length
+      by_cases h_term_exists : ∃ i ≤ ops.length, (formula.applyOps (ops.take i)).isTerminal = true
+      · -- Termination exists: find and return it
+        let i := Classical.choose h_term_exists
+        have h_i_bound : i ≤ ops.length := (Classical.choose_spec h_term_exists).1
+        have h_i_term : (formula.applyOps (ops.take i)).isTerminal = true := (Classical.choose_spec h_term_exists).2
+        have h_i_min : i ≤ min ops.length formula.countLiterals := by
+          simp [Nat.min_eq_left h_short_ops]
+          exact h_i_bound
+        exact TerminationSearchResult.Found i h_i_min h_i_term
+      · -- No termination exists: return exhaustion
+        push_neg at h_term_exists
+        have h_ops_bound : ops.length ≤ min ops.length formula.countLiterals := by
+          rw [Nat.min_eq_left h_short_ops]
+        -- h_term_exists now provides exactly what we need:
+        -- ∀ i ≤ ops.length, ¬(formula.applyOps (ops.take i)).isTerminal = true
+        exact TerminationSearchResult.Exhausted ops.length h_ops_bound rfl h_term_exists
+    · -- Case: formula.countLiterals < ops.length, so min = formula.countLiterals
+      push_neg at h_short_ops
+      have h_formula_lt : formula.countLiterals < ops.length := h_short_ops
+      have h_bound_eq : bound = formula.countLiterals := by
+        simp [bound, Nat.min_eq_right (Nat.le_of_lt h_formula_lt)]
+      -- In this case, we need to check if there's early termination before formula.countLiterals
+      -- If so, return that early termination point; otherwise, termination is forced at formula.countLiterals
+
+      -- First check: is there early termination?
+      by_cases h_early_term : ∃ i < formula.countLiterals, (formula.applyOps (ops.take i)).isTerminal = true
+      · -- Case: early termination exists
+        let i := Classical.choose h_early_term
+        have h_i_lt : i < formula.countLiterals := (Classical.choose_spec h_early_term).1
+        have h_i_terminal : (formula.applyOps (ops.take i)).isTerminal = true := (Classical.choose_spec h_early_term).2
+        -- Return i as our witness
+        have h_i_bound : i ≤ min ops.length formula.countLiterals := by
+          -- Since i < formula.countLiterals and formula.countLiterals = min(ops.length, formula.countLiterals)
+          rw [Nat.min_eq_right (Nat.le_of_lt h_formula_lt)]
+          exact Nat.le_of_lt h_i_lt
+        exact TerminationSearchResult.Found i h_i_bound h_i_terminal
+
+      · -- Case: no early termination
+        -- Then termination is forced at formula.countLiterals
+        push_neg at h_early_term
+        have h_formula_bound : formula.countLiterals ≤ min ops.length formula.countLiterals := by
+          -- Since formula.countLiterals < ops.length, min = formula.countLiterals
+          rw [Nat.min_eq_right (Nat.le_of_lt h_formula_lt)]
+        exact TerminationSearchResult.Found formula.countLiterals h_formula_bound (by
+                 -- Since no early termination up to formula.countLiterals,
+                 -- we can apply literal_count_progression
+                 have h_literal_decrease : (formula.applyOps (ops.take formula.countLiterals)).countLiterals ≤ formula.countLiterals - formula.countLiterals := by
+                   apply literal_count_progression
+                   · exact Nat.le_of_lt h_formula_lt
+                   · exact h_valid
+                   · exact h_early_term
+
+                 -- This gives us literal count = 0
+                 have h_zero_literals : (formula.applyOps (ops.take formula.countLiterals)).countLiterals = 0 := by
+                   rw [Nat.sub_self] at h_literal_decrease
+                   exact Nat.eq_zero_of_le_zero h_literal_decrease
+
+                 -- Apply zero_literals_terminal
+                 exact zero_literals_terminal (formula.applyOps (ops.take formula.countLiterals)) h_zero_literals)
+
+
+/-- Corollary: Any valid finite operation sequence either terminates or gets exhausted -/
+theorem any_valid_operation_list_terminates_or_exhausts {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (ops : List (FormulaOp Var))
+    (h_valid : ∀ i (h_bound : i < ops.length), (ops.get ⟨i, h_bound⟩).IsApplicable (formula.applyOps (ops.take i))) :
+    (∃ k ≤ ops.length, (formula.applyOps (ops.take k)).isTerminal = true) ∨
+    (ops.length ≤ formula.countLiterals ∧ ¬(formula.applyOps ops).isTerminal = true) := by
+  -- This corollary follows from the main theorem through logical case analysis
+  -- The mathematical insight: either early termination or bounded exhaustion
+
+  -- Apply the main theorem to get our fundamental result
+  have result := any_valid_operation_list_terminates_within_bound formula ops h_valid
+
+  -- The main theorem now gives us a TerminationSearchResult
+  -- We need to derive our specific disjunctive conclusion
+
+  cases result with
+  | Found k h_k_bound h_terminal =>
+    -- Case: termination found at position k
+    -- Check if this satisfies the corollary's first disjunct: k ≤ ops.length
+    have h_k_le_ops : k ≤ ops.length := Nat.le_trans h_k_bound (Nat.min_le_left _ _)
+    -- We have termination, so we return the first disjunct
+    exact Or.inl ⟨k, h_k_le_ops, h_terminal⟩
+  | Exhausted k h_k_bound h_eq h_no_term =>
+    -- Case: exhaustion without early termination (k = ops.length)
+    -- We prove the second disjunct: (ops.length ≤ formula.countLiterals ∧ ¬(formula.applyOps ops).isTerminal = true)
+
+    -- First part: ops.length ≤ formula.countLiterals
+    have h_length_bound : ops.length ≤ formula.countLiterals := by
+      rw [←h_eq]
+      exact Nat.le_trans h_k_bound (Nat.min_le_right _ _)
+
+    -- Second part: ¬(formula.applyOps ops).isTerminal = true
+    have h_final_nonterm : ¬(formula.applyOps ops).isTerminal = true := by
+      -- From h_no_term: ∀ i ≤ k, ¬(formula.applyOps (ops.take i)).isTerminal = true
+      -- Since k = ops.length, we have ∀ i ≤ ops.length, ¬(formula.applyOps (ops.take i)).isTerminal = true
+      -- In particular, for i = ops.length: ¬(formula.applyOps (ops.take ops.length)).isTerminal = true
+      -- Since ops.take ops.length = ops, this gives us ¬(formula.applyOps ops).isTerminal = true
+      have h_at_length : ¬(formula.applyOps (ops.take ops.length)).isTerminal = true := by
+        apply h_no_term
+        rw [h_eq]
+      rwa [List.take_length] at h_at_length
+
+    exact Or.inr ⟨h_length_bound, h_final_nonterm⟩
+
+end ListOperations
+

--- a/lean/SATGame/FormulaOps/Termination/Nonterminal.lean
+++ b/lean/SATGame/FormulaOps/Termination/Nonterminal.lean
@@ -1,0 +1,144 @@
+import Batteries.Data.List.Basic
+import Batteries.Tactic.Init
+import SATGame.CNF.Formula
+import SATGame.FormulaOps.FormulaExt
+
+/-!
+# Nonterminal Formulas
+
+Defines formulas that are neither empty nor contain empty clauses.
+
+This module contains:
+- Core insights about nonterminal formulas
+- Properties connecting nonterminal status to empty clauses
+- Helper theorems about clause lengths in nonterminal formulas
+- Basic structural properties (non-emptiness, variable containment)
+-/
+
+-- A. Core insight: Nonterminal formulas have no empty clauses
+theorem nonterminal_implies_no_empty_clauses {Var : Type} (formula : Formula Var)
+    (h : formula.isNonterminal = true) : Formula.hasEmptyClause formula = false := by
+  -- Use the definition of isNonterminal
+  unfold Formula.isNonterminal at h
+  unfold Formula.isTerminal at h
+  -- h : (formula.isEmpty || formula.hasEmptyClause) = false = true
+  -- This means: formula.isEmpty || formula.hasEmptyClause = false
+  -- Since OR is false, both parts must be false
+  simp at h
+  -- h is now: ¬formula.isEmpty ∧ ¬formula.hasEmptyClause
+  exact h.2
+
+-- B. Helper: Any clause at valid index in nonterminal formula is nonempty
+theorem clause_at_index_nonempty {Var : Type} (formula : Formula Var) (index : Nat)
+    (h_nonterminal : formula.isNonterminal = true)
+    (h_index : index < formula.length) :
+    (formula.get ⟨index, h_index⟩).length > 0 := by
+  -- We know nonterminal formulas have no empty clauses
+  have h_no_empty := nonterminal_implies_no_empty_clauses formula h_nonterminal
+
+  -- By contradiction: assume the clause is empty
+  by_contra h_not_pos
+  -- h_not_pos : ¬(formula.get ⟨index, h_index⟩).length > 0
+  -- This means the length is 0
+  have h_zero_length : (formula.get ⟨index, h_index⟩).length = 0 := by
+    -- In Nat, ¬(n > 0) means n = 0
+    exact Nat.eq_zero_of_not_pos h_not_pos
+
+  -- If the clause has length 0, it's empty
+  have h_clause_empty : (formula.get ⟨index, h_index⟩).isEmpty := by
+    unfold Clause.isEmpty
+    rw [List.isEmpty_iff_length_eq_zero]
+    exact h_zero_length
+
+  -- But then formula.hasEmptyClause = true (since this clause is in the formula)
+  have h_has_empty : Formula.hasEmptyClause formula = true := by
+    unfold Formula.hasEmptyClause
+    rw [List.any_eq_true]
+    exact ⟨formula.get ⟨index, h_index⟩, List.get_mem formula ⟨index, h_index⟩, h_clause_empty⟩
+
+  -- This contradicts h_no_empty
+  rw [h_has_empty] at h_no_empty
+  simp at h_no_empty
+
+-- C. Basic structural property: Nonterminal formulas are not empty
+theorem nonterminal_nonempty {Var : Type} (formula : Formula Var)
+    (h_nonterminal : formula.isNonterminal = true) :
+    formula ≠ [] := by
+  unfold Formula.isNonterminal Formula.isTerminal at h_nonterminal
+  simp at h_nonterminal
+  exact h_nonterminal.1
+
+/--
+**Nonterminal Variable Containment**: Every nonterminal formula contains at least one variable.
+
+This is a fundamental property showing that nonterminal formulas are non-trivial:
+they must contain variables that can be assigned during formula operations.
+
+The proof decomposes the structural hierarchy formula → clause → literal → variable
+through 8 logical steps, ensuring each level is non-empty and extracting components
+until a variable is found.
+-/
+theorem nonterminal_contains_variable {Var : Type} [DecidableEq Var] (formula : Formula Var)
+    (h_nonterminal : formula.isNonterminal = true) :
+    ∃ var, formula.containsVariable var = true := by
+  -- Step 1: Formula is not empty
+  have h_formula_nonempty : formula ≠ [] := nonterminal_nonempty formula h_nonterminal
+
+  -- Step 2: Extract a clause from non-empty formula
+  have h_formula_length : formula.length > 0 := by
+    cases formula with
+    | nil => contradiction
+    | cons _ _ => simp
+
+  -- Get the first clause (at index 0)
+  have h_clause_exists : ∃ (clause : Clause Var), List.Mem clause formula :=
+    ⟨formula.get ⟨0, h_formula_length⟩, List.get_mem formula ⟨0, h_formula_length⟩⟩
+
+  -- Extract the clause and its membership proof
+  let ⟨clause, h_clause_in⟩ := h_clause_exists
+
+  -- Step 3: Show the clause is not empty
+  have h_clause_nonempty : clause ≠ [] := by
+    -- We need to show this clause has no empty clauses
+    have h_no_empty_clauses := nonterminal_implies_no_empty_clauses formula h_nonterminal
+    -- If clause were empty, then formula would have an empty clause
+    by_contra h_clause_empty
+    have h_clause_isEmpty : clause.isEmpty = true := by
+      unfold Clause.isEmpty
+      rw [List.isEmpty_iff_length_eq_zero]
+      simp [h_clause_empty]
+    -- This would mean formula.hasEmptyClause = true
+    have h_has_empty : formula.hasEmptyClause = true := by
+      unfold Formula.hasEmptyClause
+      rw [List.any_eq_true]
+      exact ⟨clause, h_clause_in, h_clause_isEmpty⟩
+    -- But we know hasEmptyClause = false
+    rw [h_has_empty] at h_no_empty_clauses
+    simp at h_no_empty_clauses
+
+  -- Step 4: Extract a literal from non-empty clause
+  have h_clause_length : clause.length > 0 := by
+    cases clause with
+    | nil => contradiction
+    | cons _ _ => simp
+
+  have h_literal_exists : ∃ (literal : Literal Var), List.Mem literal clause :=
+    ⟨clause.get ⟨0, h_clause_length⟩, List.get_mem clause ⟨0, h_clause_length⟩⟩
+
+  let ⟨literal, h_literal_in⟩ := h_literal_exists
+
+  -- Step 5: Extract variable from literal
+  have h_literal_has_var : ∃ var, literal.containsVariable var = true :=
+    ⟨literal.getVariable, Literal.contains_own_variable literal⟩
+  let ⟨var, h_var_in_literal⟩ := h_literal_has_var
+
+  -- Step 6: Show clause contains the variable
+  have h_clause_contains_var : clause.containsVariable var = true :=
+    literal_var_implies_clause_var clause var ⟨literal, h_literal_in, h_var_in_literal⟩
+
+  -- Step 7: Show formula contains the variable
+  have h_formula_contains_var : formula.containsVariable var = true :=
+    clause_var_implies_formula_var formula var ⟨clause, h_clause_in, h_clause_contains_var⟩
+
+  -- Step 8: Conclude existence
+  exact ⟨var, h_formula_contains_var⟩

--- a/lean/SATGame/FormulaOps/Termination/RemoveClause.lean
+++ b/lean/SATGame/FormulaOps/Termination/RemoveClause.lean
@@ -1,0 +1,67 @@
+import SATGame.FormulaOps.FormulaExt
+import SATGame.FormulaOps.FormulaOps
+import SATGame.FormulaOps.Termination.Nonterminal
+import SATGame.Util.List
+
+/-!
+# Remove Clause Termination
+
+Proves that removing clauses decreases literal count.
+
+Key: Nonterminal formulas have no empty clauses, so removing any clause
+removes at least one literal.
+-/
+
+theorem removeClause_decreases_literalCount {Var : Type} (formula : Formula Var) (index : Nat)
+    (h_nonterminal : formula.isNonterminal = true)
+    (h_index : index < formula.length) :
+    (formula.removeClause index).countLiterals < formula.countLiterals := by
+  -- The key insight: nonterminal formulas have no empty clauses,
+  -- so the clause we're removing must contain at least one literal
+  have h_clause_nonempty := clause_at_index_nonempty formula index h_nonterminal h_index
+  -- Apply the general list utility: removing an element with positive
+  -- contribution (clause.length > 0) decreases the total sum (literalCount)
+  apply sum_eraseIdx_lt formula (fun clause => clause.length) index h_index h_clause_nonempty
+
+/--
+**Clause Removal Sequences are Nonincreasing**: Any sequence of clause removals
+can only decrease or maintain the literal count.
+
+This fundamental property shows that clause removal operations are "safe" in the sense
+that they never increase the complexity (literal count) of a formula.
+-/
+theorem clause_removal_sequence_nonincreasing {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (removals : List (FormulaOp Var))
+    (h_all_removals : ∀ op ∈ removals, ∃ index, op = FormulaOp.RemoveClause index) :
+    (removals.foldl Formula.applyOp formula).countLiterals ≤ formula.countLiterals := by
+  -- Induction on the list of removal operations
+  induction removals generalizing formula with
+  | nil =>
+    -- Base case: empty list of operations
+    simp [List.foldl_nil]
+  | cons op rest ih =>
+    -- Inductive case: op :: rest
+    simp [List.foldl_cons]
+    -- Show that op is a removeClause operation
+    obtain ⟨index, h_op_eq⟩ := h_all_removals op (by simp)
+    -- Show that removeClause is nonincreasing
+    have h_single_nonincreasing : (formula.applyOp op).countLiterals ≤ formula.countLiterals := by
+      rw [h_op_eq]
+      unfold Formula.applyOp Formula.removeClause Formula.countLiterals
+      -- removeClause always decreases or preserves literal count
+      by_cases h_index : index < formula.length
+      · -- Valid index: erasing an element never increases the sum
+        have h_eraseIdx_le : ((formula.eraseIdx index).map List.length).sum ≤ (formula.map List.length).sum := by
+          -- This is a general property: removing an element from a list never increases the sum
+          exact List.sum_map_eraseIdx_le formula List.length index
+        exact h_eraseIdx_le
+      · -- Invalid index: no change (eraseIdx does nothing)
+        simp [List.eraseIdx_of_length_le (Nat.le_of_not_gt h_index)]
+    -- Apply the inductive hypothesis to the rest of the operations on the new formula
+    have ih_applied := ih (formula.applyOp op) (by
+      intros op' h_mem
+      exact h_all_removals op' (List.mem_cons_of_mem op h_mem))
+    -- Combine: first operation is nonincreasing, then rest is nonincreasing
+    -- ih_applied shows: (rest.foldl Formula.applyOp (formula.applyOp op)).countLiterals ≤ (formula.applyOp op).countLiterals
+    -- h_single_nonincreasing shows: (formula.applyOp op).countLiterals ≤ formula.countLiterals
+    exact Nat.le_trans ih_applied h_single_nonincreasing

--- a/lean/SATGame/FormulaOps/Termination/SetVariable.lean
+++ b/lean/SATGame/FormulaOps/Termination/SetVariable.lean
@@ -1,0 +1,190 @@
+import Batteries.Data.List.Basic
+import Batteries.Tactic.Init
+import SATGame.Boolean.Literal
+import SATGame.FormulaOps.FormulaExt
+import SATGame.FormulaOps.Termination.Helpers
+import SATGame.FormulaOps.Termination.Helpers.SetVariableHelpers
+import SATGame.FormulaOps.Termination.Nonterminal
+import SATGame.Util.List
+
+/-!
+# Set Variable Termination
+
+Proves that variable assignment decreases literal count.
+
+Setting x := value transforms the formula by:
+1. Removing clauses satisfied by x (or ¬x)
+2. Filtering x (or ¬x) from remaining clauses
+
+Both decrease literal count since the variable appears somewhere in the formula.
+-/
+
+-- Helper: Extract a specific clause that contains the variable we're assigning
+theorem extract_witness_clause {Var : Type} [DecidableEq Var] (formula : Formula Var) (var : Var)
+    (h_contains : formula.any (fun clause => clause.any (fun lit => match lit with
+      | Literal.pos v => v = var
+      | Literal.neg v => v = var))) :
+    ∃ clause, List.Mem clause formula ∧ clause.any (fun lit => match lit with
+      | Literal.pos v => v = var
+      | Literal.neg v => v = var) := by
+  rw [List.any_eq_true] at h_contains
+  obtain ⟨clause, h_clause_mem, h_clause_has_var⟩ := h_contains
+  exact ⟨clause, h_clause_mem, h_clause_has_var⟩
+
+
+-- Helper: Extract a specific literal from a clause that contains the variable
+theorem extract_witness_literal {Var : Type} [DecidableEq Var] (clause : Clause Var) (var : Var)
+    (h_contains : ∃ lit, List.Mem lit clause ∧ match lit with
+      | Literal.pos v => v = var
+      | Literal.neg v => v = var) :
+    ∃ lit : Literal Var, List.Mem lit clause ∧
+    (match lit with | Literal.pos v => v = var | Literal.neg v => v = var) := by
+  obtain ⟨lit, h_lit_mem, h_lit_has_var⟩ := h_contains
+  exact ⟨lit, h_lit_mem, h_lit_has_var⟩
+
+
+-- KEY HELPER: processClauseForVariableAssignment never increases, and decreases for clauses with variable
+theorem processClause_literal_count_behavior {Var : Type} [DecidableEq Var]
+    (clause : Clause Var) (var : Var) (value : Bool) :
+    match processClauseForVariableAssignment clause var value with
+    | none => True  -- Clause removed entirely
+    | some result =>
+        result.length ≤ clause.length ∧
+        (Clause.containsVariable clause var = true → result.length < clause.length)
+    := by
+  unfold processClauseForVariableAssignment
+  -- Case analysis: is the clause satisfied?
+  by_cases h_satisfied : Clause.satisfiedBy clause var value = true
+  · -- Case: clause is satisfied, maps to none
+    rw [if_pos h_satisfied]
+    trivial
+  · -- Case: clause is not satisfied, maps to filtered clause
+    rw [if_neg h_satisfied]
+    simp only
+
+    constructor
+    · -- Prove: (clause.filter ...).length ≤ clause.length
+      apply List.length_filter_le
+
+    · -- Prove: Clause.containsVariable clause var = true → (clause.filter ...).length < clause.length
+      intro h_contains
+      -- If clause contains var, then filtering out literals with var must remove at least one
+      -- Convert h_contains to existence of literal with var
+      unfold Clause.containsVariable at h_contains
+      rw [List.any_eq_true] at h_contains
+      obtain ⟨lit, h_lit_mem, h_lit_has_var⟩ := h_contains
+
+      -- This literal will be filtered out (since it contains the variable)
+      have h_lit_not_in_filtered := literal_with_var_filtered_out clause var lit h_lit_mem h_lit_has_var
+
+      -- Apply our general theorem about filtering removing elements
+      exact filter_removes_element_strict clause (fun l => ¬(l.containsVariable var)) lit h_lit_mem h_lit_not_in_filtered
+
+/--
+Helper theorem: In nonterminal formulas, any clause containing a variable is nonempty.
+
+This follows from the fact that nonterminal formulas have no empty clauses.
+-/
+theorem witness_clause_nonempty {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (clause : Clause Var) (var : Var)
+    (h_nonterminal : formula.isNonterminal = true)
+    (h_clause_mem : List.Mem clause formula)
+    (_ : clause.containsVariable var) :
+    clause.length > 0 := by
+  have h_no_empty := nonterminal_implies_no_empty_clauses formula h_nonterminal
+  by_contra h_not_pos
+  have h_zero_length : clause.length = 0 := Nat.eq_zero_of_not_pos h_not_pos
+  have h_empty : clause.isEmpty := by
+    rw [List.length_eq_zero_iff] at h_zero_length
+    rw [h_zero_length]; rfl
+  have h_formula_has_empty : formula.hasEmptyClause = true := by
+    unfold Formula.hasEmptyClause; rw [List.any_eq_true]; exact ⟨clause, h_clause_mem, h_empty⟩
+  rw [h_formula_has_empty] at h_no_empty; exact Bool.noConfusion h_no_empty
+
+/--
+Helper theorem: Processing clauses during variable assignment preserves non-increase property.
+
+This encapsulates the proof that other clauses don't increase in length during processing.
+-/
+theorem process_clauses_nonincreasing {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool) :
+    ∀ clause, List.Mem clause formula →
+    ∀ result, processClauseForVariableAssignment clause var value = some result →
+    result.length ≤ clause.length := by
+  intro clause _ result h_maps
+  have h_behavior := processClause_literal_count_behavior clause var value
+  rw [h_maps] at h_behavior
+  exact h_behavior.1
+
+/--
+Helper theorem: When a clause is satisfied and removed, we decrease the total literal count.
+
+This handles the case where `processClauseForVariableAssignment` returns `none`.
+-/
+theorem setVariable_decreases_when_clause_removed {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool)
+    (witness_clause : Clause Var)
+    (h_witness_mem : List.Mem witness_clause formula)
+    (h_witness_removed : processClauseForVariableAssignment witness_clause var value = none)
+    (h_witness_nonempty : witness_clause.length > 0) :
+    (formula.setVariable var value).countLiterals < formula.countLiterals := by
+  unfold Formula.setVariable Formula.countLiterals
+  apply List.sum_filterMap_lt_of_witness_removed
+    formula (fun clause => clause.length) (processClauseForVariableAssignment · var value) (fun clause => clause.length)
+    witness_clause h_witness_mem h_witness_removed h_witness_nonempty
+  exact process_clauses_nonincreasing formula var value
+
+/--
+Helper theorem: When a clause is shortened, we decrease the total literal count.
+
+This handles the case where `processClauseForVariableAssignment` returns a smaller clause.
+-/
+theorem setVariable_decreases_when_clause_shortened {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool)
+    (witness_clause : Clause Var) (witness_result : Clause Var)
+    (h_witness_mem : List.Mem witness_clause formula)
+    (h_witness_contains : witness_clause.containsVariable var)
+    (h_witness_process : processClauseForVariableAssignment witness_clause var value = some witness_result) :
+    (formula.setVariable var value).countLiterals < formula.countLiterals := by
+  unfold Formula.setVariable Formula.countLiterals
+  have h_witness_decreases : witness_result.length < witness_clause.length := by
+    have h_behavior := processClause_literal_count_behavior witness_clause var value
+    rw [h_witness_process] at h_behavior
+    exact h_behavior.2 h_witness_contains
+  apply List.sum_filterMap_lt_of_witness_decreased
+    formula (fun clause => clause.length) (processClauseForVariableAssignment · var value) (fun clause => clause.length)
+    witness_clause h_witness_mem witness_result h_witness_process h_witness_decreases
+  exact process_clauses_nonincreasing formula var value
+
+/--
+**Main Termination Theorem**: Setting a variable in a nonterminal formula decreases literal count.
+
+This theorem establishes that variable assignment always decreases the termination measure.
+The proof works by:
+1. Extracting a witness clause that contains the variable
+2. Showing this clause is nonempty (since the formula is nonterminal)
+3. Case analysis on whether the clause is satisfied (removed) or unsatisfied (shortened)
+4. In both cases, the literal count strictly decreases
+-/
+theorem setVariable_decreases_literalCount {Var : Type} [DecidableEq Var]
+    (formula : Formula Var) (var : Var) (value : Bool)
+    (h_nonterminal : formula.isNonterminal = true)
+    (h_contains : formula.any (fun clause => clause.containsVariable var)) :
+    (formula.setVariable var value).countLiterals < formula.countLiterals := by
+  -- Extract witness clause containing the variable
+  rw [List.any_eq_true] at h_contains
+  obtain ⟨witness_clause, h_witness_mem, h_witness_contains⟩ := h_contains
+
+  -- Witness clause is nonempty (since formula is nonterminal)
+  have h_witness_nonempty := witness_clause_nonempty formula witness_clause var h_nonterminal h_witness_mem h_witness_contains
+
+  -- Case analysis on what happens to the witness clause during processing
+  cases h_witness_process : processClauseForVariableAssignment witness_clause var value with
+  | none =>
+    -- Witness clause is satisfied and removed
+    exact setVariable_decreases_when_clause_removed formula var value
+      witness_clause h_witness_mem h_witness_process h_witness_nonempty
+  | some witness_result =>
+    -- Witness clause is shortened but not removed
+    exact setVariable_decreases_when_clause_shortened formula var value
+      witness_clause witness_result h_witness_mem h_witness_contains h_witness_process

--- a/lean/SATGame/Util/List.lean
+++ b/lean/SATGame/Util/List.lean
@@ -176,6 +176,43 @@ theorem List.sum_map_eraseIdx_le {α : Type} (l : List α) (f : α → Nat) (ind
   · -- Invalid index: no change
     simp [List.eraseIdx_of_length_le (Nat.le_of_not_gt h_index)]
 
+-- If a list contains an element > 0, then the sum > 0
+theorem List.sum_pos (l : List Nat) (h : ∃ x ∈ l, x > 0) : l.sum > 0 := by
+  -- Use list induction on the structure
+  induction l with
+  | nil =>
+    -- Impossible case: x cannot be in empty list
+    let ⟨x, h_mem, h_pos⟩ := h
+    simp at h_mem
+  | cons head tail ih =>
+    -- Extract the witness: there exists an element x in head::tail with x > 0
+    let ⟨x, h_mem, h_pos⟩ := h
+    -- Case analysis: is x the head or in the tail?
+    by_cases h_eq : head = x
+    · -- Case: head is our positive element
+      subst h_eq
+      -- Sum = head + tail.sum = x + tail.sum > 0 since x > 0
+      simp [List.sum_cons]
+      exact Nat.add_pos_left h_pos tail.sum
+    · -- Case: x is in the tail
+      have h_mem_tail : x ∈ tail := by
+        rw [List.mem_cons] at h_mem
+        cases h_mem with
+        | inl h => exact absurd h.symm h_eq
+        | inr h => exact h
+      -- Apply induction hypothesis: tail.sum > 0
+      have ih_applied : tail.sum > 0 := ih ⟨x, h_mem_tail, h_pos⟩
+      -- Therefore head + tail.sum > head + 0 = head ≥ 0, so total > 0
+      simp [List.sum_cons]
+      exact Nat.add_pos_right head ih_applied
+
+-- If a list contains an element ≥ 1, then the sum > 0
+theorem List.sum_pos_of_mem_ge_one (l : List Nat) (h : ∃ x ∈ l, x ≥ 1) : l.sum > 0 := by
+  -- Convert ≥ 1 to > 0 and apply the previous theorem
+  let ⟨x, h_mem, h_ge_one⟩ := h
+  have h_pos : x > 0 := Nat.pos_of_ne_zero (Nat.ne_of_gt (Nat.succ_le_iff.mp h_ge_one))
+  exact List.sum_pos l ⟨x, h_mem, h_pos⟩
+
 -- Removing an element with positive contribution decreases the sum
 theorem sum_eraseIdx_lt {α : Type} (l : List α) (f : α → Nat) (index : Nat)
     (h_index : index < l.length)

--- a/lean/lakefile.toml
+++ b/lean/lakefile.toml
@@ -8,5 +8,10 @@ name = "batteries"
 scope = "leanprover-community"
 rev = "v4.20.0"
 
+[[require]]
+name = "mathlib"
+scope = "leanprover-community"
+rev = "v4.20.0"
+
 [[lean_lib]]
 name = "SATGame"


### PR DESCRIPTION
## Complete Termination Proof for Boolean Formula Operations

This PR proves that all valid sequences of Boolean formula operations terminate within bounded steps, establishing the mathematical foundation for the SAT Game.

### Summary

Adds formal proof that any valid operation sequence terminates within `formula.countLiterals` steps, with **zero sorries**.

### Key Changes

- **Main theorem**: Proves termination bound using new `TerminationSearchResult` type for explicit semantics
- **Helper proofs**: Individual termination properties for SetVariable and RemoveClause operations  
- **Infrastructure**: Supporting lemmas for literal count tracking and formula properties
- **Documentation**: Improved clarity in FormulaOps modules

### Technical Highlights

- Uses well-founded induction on literal count decrease
- Pattern matching on `TerminationSearchResult` eliminates ambiguity
- Classical reasoning extracts constructive termination witnesses

### Files: 11 changed, +1,658 lines

Main additions:
- `SATGame/FormulaOps/Termination/Main.lean` (907 lines)
- Helper modules for SetVariable, RemoveClause, and utilities
- Documentation improvements in existing files

### Verification

✅ Builds successfully  
✅ Zero sorries  
✅ All operation sequences proven to terminate

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>